### PR TITLE
RuleAction.Block enhancements

### DIFF
--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineCreateTests.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineCreateTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Xunit;
 
@@ -195,6 +196,26 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
             Assert.Equal(default, valueTypes.JsonIgnoredProp);
             Assert.Equal(default, valueTypes.JsonIgnoredChild);
         }
+
+        public static IEnumerable<object[]> CreateWithBlockData()
+        {
+            yield return new object[] { new Entity { BlockInteger = 123 }, "BlockInteger" };
+            yield return new object[] { new Entity { BlockString = "Hello World" }, "BlockString" };
+            yield return new object[] { new Entity { BlockGuid = Guid.NewGuid() }, "BlockGuid" };
+            yield return new object[] { new Entity { BlockState = State.Active }, "BlockState" };
+            yield return new object[] { new Entity { BlockTestObject = new() }, "BlockTestObject" };
+        }
+
+        [Theory]
+        [MemberData(nameof(CreateWithBlockData))]
+        public void CreateWithBlock(Entity exemplar, string propertyName)
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+
+            var exception = Assert.Throws<DryException>(() => rules.Create(exemplar));
+
+            Assert.Equal($"Invalid attempt to change property '{propertyName}'", exception.Message);
+        }
     }
 
     public class Entity {
@@ -214,8 +235,6 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
         public State State { get; set; }
         [Rules(CreateAction = RuleAction.Allow)]
         public ChildEntity TestObject { get; set; }
-        [Rules(CreateAction = RuleAction.Allow)]
-        public ChildEntity ExistingTestObject { get; set; }
         [Rules(CreateAction = RuleAction.Allow)]
         public ChildEntity DesendantsTestObject { get; set; }
         
@@ -250,6 +269,18 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
         public int JsonIgnoredProp { get; set; }
         [JsonIgnore]
         public ChildEntity JsonIgnoredChild { get; set; }
+
+
+        [Rules(CreateAction = RuleAction.Block)]
+        public int BlockInteger { get; set; }
+        [Rules(CreateAction = RuleAction.Block)]
+        public string BlockString { get; set; }
+        [Rules(CreateAction = RuleAction.Block)]
+        public Guid BlockGuid { get; set; }
+        [Rules(CreateAction = RuleAction.Block)]
+        public State BlockState { get; set; }
+        [Rules(CreateAction = RuleAction.Block)]
+        public ChildEntity BlockTestObject { get; set; }
     }
         
     public class ChildEntity {

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineUpdateIndividualAsyncTests.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core.Tests/Rules/RuleEngineUpdateIndividualAsyncTests.cs
@@ -11,6 +11,7 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
         {
             var rules = new RuleEngine(new ServiceProviderStub());
             var source = SampleEntity();
+            source.Id = 0;
             var destination = SampleEntity();
 
             await rules.UpdateAsync(source, destination);
@@ -30,7 +31,7 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
             var rules = new RuleEngine(new ServiceProviderStub());
             var source = SampleEntity();
             var destination = SampleEntity();
-            source.Id = 2;
+            source.HoursWorked = 2;
 
             await Assert.ThrowsAsync<DryException>(async () => await rules.UpdateAsync(source, destination));
         }
@@ -242,6 +243,9 @@ namespace Blazor.ExtraDry.Core.Tests.Rules {
 
             [Rules(RuleAction.Block)]
             public string BlockChangesString { get; set; }
+
+            [Rules(RuleAction.Block)]
+            public int HoursWorked { get; set; }
 
         }
 

--- a/Blazor.ExtraDry/Blazor.ExtraDry.Core/ExtensionMethods/PropertyInfoExtensions.cs
+++ b/Blazor.ExtraDry/Blazor.ExtraDry.Core/ExtensionMethods/PropertyInfoExtensions.cs
@@ -1,10 +1,17 @@
 ﻿using System.Reflection;
+using System.Text.Json.Serialization;
 
 namespace Blazor.ExtraDry.Core.ExtensionMethods {
     public static class PropertyInfoExtensions {
         public static bool IsValueOrImmutable(this PropertyInfo propertyInfo)
         {
             return propertyInfo.PropertyType.IsClass && propertyInfo.PropertyType != typeof(string);
+        }
+
+        public static bool IsJsonIgnored(this PropertyInfo propertyInfo)
+        {
+            var ignoreAttribute = propertyInfo.GetCustomAttribute<JsonIgnoreAttribute>();
+            return ignoreAttribute != null && ignoreAttribute.Condition == JsonIgnoreCondition.Always;
         }
     }
 }


### PR DESCRIPTION
- The exception raised when trying to update a `RuleAction.Block` property is suppressed if the property is `JsonIgnored`.
- The `RuleEngine` `Create` method has been enhanced to use `RuleAction.Block`.