### PR TITLE
RuleAction.Block enhancements

### DIFF
--- a/ExtraDry/ExtraDry.Core.Tests/Rules/RuleEngineCreateTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Rules/RuleEngineCreateTests.cs
@@ -1,6 +1,6 @@
-using ExtraDry.Core;
 using ExtraDry.Server;
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Xunit;
 
@@ -116,7 +116,7 @@ namespace ExtraDry.Core.Tests.Rules {
             Assert.NotNull(entity.DesendantsTestObject.TestObject);
             Assert.NotEqual(exemplar.DesendantsTestObject.TestObject, entity.DesendantsTestObject.TestObject);
         }
-        
+
         [Fact]
         public void CreateWithInvalidReferenceType()
         {
@@ -197,6 +197,26 @@ namespace ExtraDry.Core.Tests.Rules {
             Assert.Equal(default, valueTypes.JsonIgnoredProp);
             Assert.Equal(default, valueTypes.JsonIgnoredChild);
         }
+
+        public static IEnumerable<object[]> CreateWithBlockData()
+        {
+            yield return new object[] { new Entity { BlockInteger = 123 }, "BlockInteger" };
+            yield return new object[] { new Entity { BlockString = "Hello World" }, "BlockString" };
+            yield return new object[] { new Entity { BlockGuid = Guid.NewGuid() }, "BlockGuid" };
+            yield return new object[] { new Entity { BlockState = State.Active }, "BlockState" };
+            yield return new object[] { new Entity { BlockTestObject = new() }, "BlockTestObject" };
+        }
+
+        [Theory]
+        [MemberData(nameof(CreateWithBlockData))]
+        public void CreateWithBlock(Entity exemplar, string propertyName)
+        {
+            var rules = new RuleEngine(new ServiceProviderStub());
+
+            var exception = Assert.Throws<DryException>(() => rules.Create(exemplar));
+
+            Assert.Equal($"Invalid attempt to change property '{propertyName}'", exception.Message);
+        }
     }
 
     public class Entity {
@@ -217,10 +237,8 @@ namespace ExtraDry.Core.Tests.Rules {
         [Rules(CreateAction = RuleAction.Allow)]
         public ChildEntity TestObject { get; set; }
         [Rules(CreateAction = RuleAction.Allow)]
-        public ChildEntity ExistingTestObject { get; set; }
-        [Rules(CreateAction = RuleAction.Allow)]
         public ChildEntity DesendantsTestObject { get; set; }
-        
+
         [Rules(CreateAction = RuleAction.Ignore)]
         public int IgnoredProp { get; set; }
         [Rules(CreateAction = RuleAction.Ignore)]
@@ -252,8 +270,20 @@ namespace ExtraDry.Core.Tests.Rules {
         public int JsonIgnoredProp { get; set; }
         [JsonIgnore]
         public ChildEntity JsonIgnoredChild { get; set; }
+
+
+        [Rules(CreateAction = RuleAction.Block)]
+        public int BlockInteger { get; set; }
+        [Rules(CreateAction = RuleAction.Block)]
+        public string BlockString { get; set; }
+        [Rules(CreateAction = RuleAction.Block)]
+        public Guid BlockGuid { get; set; }
+        [Rules(CreateAction = RuleAction.Block)]
+        public State BlockState { get; set; }
+        [Rules(CreateAction = RuleAction.Block)]
+        public ChildEntity BlockTestObject { get; set; }
     }
-        
+
     public class ChildEntity {
         public string PropertyOne { get; set; }
         public string PropertyTwo { get; set; }

--- a/ExtraDry/ExtraDry.Core.Tests/Rules/RuleEngineUpdateIndividualAsyncTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Rules/RuleEngineUpdateIndividualAsyncTests.cs
@@ -1,5 +1,4 @@
-﻿using ExtraDry.Core;
-using ExtraDry.Server;
+﻿using ExtraDry.Server;
 using System;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
@@ -13,6 +12,7 @@ namespace ExtraDry.Core.Tests.Rules {
         {
             var rules = new RuleEngine(new ServiceProviderStub());
             var source = SampleEntity();
+            source.Id = 0;
             var destination = SampleEntity();
 
             await rules.UpdateAsync(source, destination);
@@ -32,7 +32,7 @@ namespace ExtraDry.Core.Tests.Rules {
             var rules = new RuleEngine(new ServiceProviderStub());
             var source = SampleEntity();
             var destination = SampleEntity();
-            source.Id = 2;
+            source.HoursWorked = 2;
 
             await Assert.ThrowsAsync<DryException>(async () => await rules.UpdateAsync(source, destination));
         }
@@ -245,6 +245,8 @@ namespace ExtraDry.Core.Tests.Rules {
             [Rules(RuleAction.Block)]
             public string BlockChangesString { get; set; }
 
+            [Rules(RuleAction.Block)]
+            public int HoursWorked { get; set; }
         }
 
         private Entity SampleEntity() => new Entity();

--- a/ExtraDry/ExtraDry.Core/Server/ExtensionMethods/PropertyInfoExtensions.cs
+++ b/ExtraDry/ExtraDry.Core/Server/ExtensionMethods/PropertyInfoExtensions.cs
@@ -1,17 +1,10 @@
 ﻿using System.Reflection;
-using System.Text.Json.Serialization;
 
 namespace ExtraDry.Server {
     public static class PropertyInfoExtensions {
         public static bool IsValueOrImmutable(this PropertyInfo propertyInfo)
         {
             return propertyInfo.PropertyType.IsClass && propertyInfo.PropertyType != typeof(string);
-        }
-
-        public static bool IsJsonIgnored(this PropertyInfo propertyInfo)
-        {
-            var ignoreAttribute = propertyInfo.GetCustomAttribute<JsonIgnoreAttribute>();
-            return ignoreAttribute != null && ignoreAttribute.Condition == JsonIgnoreCondition.Always;
         }
     }
 }

--- a/ExtraDry/ExtraDry.Core/Server/ExtensionMethods/PropertyInfoExtensions.cs
+++ b/ExtraDry/ExtraDry.Core/Server/ExtensionMethods/PropertyInfoExtensions.cs
@@ -1,10 +1,17 @@
 ﻿using System.Reflection;
+using System.Text.Json.Serialization;
 
 namespace ExtraDry.Server {
     public static class PropertyInfoExtensions {
         public static bool IsValueOrImmutable(this PropertyInfo propertyInfo)
         {
             return propertyInfo.PropertyType.IsClass && propertyInfo.PropertyType != typeof(string);
+        }
+
+        public static bool IsJsonIgnored(this PropertyInfo propertyInfo)
+        {
+            var ignoreAttribute = propertyInfo.GetCustomAttribute<JsonIgnoreAttribute>();
+            return ignoreAttribute != null && ignoreAttribute.Condition == JsonIgnoreCondition.Always;
         }
     }
 }

--- a/ExtraDry/ExtraDry.Core/Server/RuleEngine.cs
+++ b/ExtraDry/ExtraDry.Core/Server/RuleEngine.cs
@@ -31,8 +31,8 @@ namespace ExtraDry.Server {
             var destination = Activator.CreateInstance<T>();
             var properties = typeof(T).GetProperties();
             foreach(var property in properties) {
-                var ignore = property.GetCustomAttribute<JsonIgnoreAttribute>();
-                if(ignore != null && ignore.Condition == JsonIgnoreCondition.Always) {
+                var ignore = property.IsJsonIgnored();
+                if(ignore) {
                     continue;
                 }
                 var rule = property.GetCustomAttribute<RulesAttribute>();
@@ -96,7 +96,7 @@ namespace ExtraDry.Server {
             var properties = typeof(T).GetProperties();
             foreach(var property in properties) {
                 var rule = property.GetCustomAttribute<RulesAttribute>();
-                var ignore = property.GetCustomAttribute<JsonIgnoreAttribute>();
+                var ignore = property.IsJsonIgnored();
                 var action = EffectiveRule(rule, ignore, e => e.UpdateAction, RuleAction.Allow);
                 if(action == RuleAction.Ignore) {
                     continue;
@@ -112,17 +112,17 @@ namespace ExtraDry.Server {
                     await ProcessCollectionUpdates(action, property, destination, sourceList);
                 }
                 else {
-                    await ProcessIndividualUpdate(action, property, destination, sourceValue, depth);
+                    await ProcessIndividualUpdate(action, property, destination, sourceValue, depth, ignore);
                 }
             }
         }
 
-        private static RuleAction EffectiveRule(RulesAttribute? rules, JsonIgnoreAttribute? ignore, Func<RulesAttribute, RuleAction> selector, RuleAction defaultType)
+        private static RuleAction EffectiveRule(RulesAttribute? rules, bool ignore, Func<RulesAttribute, RuleAction> selector, RuleAction defaultType)
         {
             if(rules != null) {
                 return selector(rules);
             }
-            else if(ignore != null && ignore.Condition == JsonIgnoreCondition.Always) {
+            else if(ignore) {
                 return RuleAction.Ignore;
             }
             else {
@@ -130,7 +130,7 @@ namespace ExtraDry.Server {
             }
         }
 
-        private async Task ProcessIndividualUpdate<T>(RuleAction action, PropertyInfo property, T destination, object? value, int depth)
+        private async Task ProcessIndividualUpdate<T>(RuleAction action, PropertyInfo property, T destination, object? value, int depth, bool ignore)
         {
             if(action == RuleAction.IgnoreDefaults && value == default) {
                 // Don't modify destination as source is in default state
@@ -149,6 +149,9 @@ namespace ExtraDry.Server {
             else {
                 var same = (result == null && destinationValue == null) || (result?.Equals(destinationValue) ?? false);
                 if(action == RuleAction.Block && !same) {
+                    if(ignore) {
+                        return;
+                    }
                     throw new DryException($"Invalid attempt to change property {property.Name}", $"Attempt to change read-only property '{property.Name}'");
                 }
                 property.SetValue(destination, result);


### PR DESCRIPTION
- The exception raised when trying to update a `RuleAction.Block` property is suppressed if the property is `JsonIgnored`.
- The `RuleEngine` `Create` method has been enhanced to use `RuleAction.Block`.