### PR TITLE
Enhancement to sort and filter.

### DIFF
--- a/ExtraDry/ExtraDry.Blazor/Components/DryVideoCapture.razor
+++ b/ExtraDry/ExtraDry.Blazor/Components/DryVideoCapture.razor
@@ -55,7 +55,7 @@
   protected override async Task OnInitializedAsync()
   {
     Console.WriteLine("About to import bundle");
-    module = await JSRuntime.InvokeAsync<IJSObjectReference>("import", "./bundles/blazor-extra-dry.razor.min.js");
+    module = await JSRuntime.InvokeAsync<IJSObjectReference>("import", "./bundles/blazor-extra-dry.min.js");
     State = FiniteState.Waiting;
   }
 

--- a/ExtraDry/ExtraDry.Core.Tests/Internals/FilterPropertyTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Internals/FilterPropertyTests.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 
-using ExtraDry.Core;
 using ExtraDry.Server.Internal;
 using Xunit;
 
@@ -13,10 +12,11 @@ namespace ExtraDry.Core.Tests.Internals {
             var property = GetType().GetProperty(nameof(ValidProperty));
             var attribute = new FilterAttribute();
 
-            var filter = new FilterProperty(property!, attribute);
+            var filter = new FilterProperty(property!, attribute, property!.Name);
 
             Assert.Equal(property, filter.Property);
             Assert.Equal(attribute, filter.Filter);
+            Assert.Equal(property.Name, filter.ExternalName);
         }
 
         [Theory]
@@ -24,7 +24,7 @@ namespace ExtraDry.Core.Tests.Internals {
         [InlineData("Filter", null)]
         public void RoundtripProperties(string propertyName, object propertyValue)
         {
-            var filter = ValidProperty;
+            var filter = FilterProperty;
             var property = filter.GetType().GetProperty(propertyName);
 
             property?.SetValue(filter, propertyValue);
@@ -33,11 +33,13 @@ namespace ExtraDry.Core.Tests.Internals {
             Assert.Equal(propertyValue, result);
         }
 
-        private FilterProperty ValidProperty {
+        public string ValidProperty { get; set; } = string.Empty;
+
+        private FilterProperty FilterProperty {
             get {
                 var property = GetType().GetProperty(nameof(ValidProperty));
                 var filter = new FilterAttribute();
-                return new FilterProperty(property!, filter);
+                return new FilterProperty(property!, filter, property!.Name);
             }
         } 
 

--- a/ExtraDry/ExtraDry.Core.Tests/Internals/FilterPropertyTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Internals/FilterPropertyTests.cs
@@ -12,7 +12,7 @@ namespace ExtraDry.Core.Tests.Internals {
             var property = GetType().GetProperty(nameof(ValidProperty));
             var attribute = new FilterAttribute();
 
-            var filter = new FilterProperty(property!, attribute, property!.Name);
+            var filter = new FilterProperty(property!, attribute);
 
             Assert.Equal(property, filter.Property);
             Assert.Equal(attribute, filter.Filter);
@@ -39,7 +39,7 @@ namespace ExtraDry.Core.Tests.Internals {
             get {
                 var property = GetType().GetProperty(nameof(ValidProperty));
                 var filter = new FilterAttribute();
-                return new FilterProperty(property!, filter, property!.Name);
+                return new FilterProperty(property!, filter);
             }
         } 
 

--- a/ExtraDry/ExtraDry.Core.Tests/Internals/LinqBuilderFilterTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Internals/LinqBuilderFilterTests.cs
@@ -144,7 +144,7 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var property = typeof(Datum).GetProperty(propertyName);
             var filter = property.GetCustomAttributes(false).First() as FilterAttribute;
-            return new FilterProperty(property, filter, property.Name);
+            return new FilterProperty(property, filter);
         }
 
         public class Datum {
@@ -179,7 +179,7 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var property = typeof(SimpleDatum).GetProperty(propertyName);
             var filter = property.GetCustomAttributes(false).First() as FilterAttribute;
-            return new FilterProperty(property, filter, property.Name);
+            return new FilterProperty(property, filter);
         }
 
         public class SimpleDatum {

--- a/ExtraDry/ExtraDry.Core.Tests/Internals/LinqBuilderFilterTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Internals/LinqBuilderFilterTests.cs
@@ -144,7 +144,7 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var property = typeof(Datum).GetProperty(propertyName);
             var filter = property.GetCustomAttributes(false).First() as FilterAttribute;
-            return new FilterProperty(property, filter);
+            return new FilterProperty(property, filter, property.Name);
         }
 
         public class Datum {
@@ -179,7 +179,7 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var property = typeof(SimpleDatum).GetProperty(propertyName);
             var filter = property.GetCustomAttributes(false).First() as FilterAttribute;
-            return new FilterProperty(property, filter);
+            return new FilterProperty(property, filter, property.Name);
         }
 
         public class SimpleDatum {

--- a/ExtraDry/ExtraDry.Core.Tests/Internals/LinqBuilderTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Internals/LinqBuilderTests.cs
@@ -1,5 +1,4 @@
 ﻿using ExtraDry.Server.Internal;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -81,7 +80,6 @@ namespace ExtraDry.Core.Tests.Internals {
         public void ThenByDescendingCompatible()
         {
             var linqSorted = SampleData.OrderByDescending(e => e.FirstName).ThenByDescending(e => e.Number).ToList();
-            var modelDescription = new ModelDescription(typeof(Datum));
 
             var linqBuilderSorted = SampleData.AsQueryable().OrderByDescending("FirstName").ThenByDescending("Number").ToList();
 
@@ -137,7 +135,7 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var property = typeof(Datum).GetProperty(propertyName);
             var filter = property.GetCustomAttributes(false).First() as FilterAttribute;
-            return new FilterProperty(property, filter, property.Name);
+            return new FilterProperty(property, filter);
         }
 
         public class Datum {

--- a/ExtraDry/ExtraDry.Core.Tests/Internals/LinqBuilderTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Internals/LinqBuilderTests.cs
@@ -1,6 +1,9 @@
-﻿using ExtraDry.Server.Internal;
+using ExtraDry.Server.Internal;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Text.Json.Serialization;
 using Xunit;
 
 namespace ExtraDry.Core.Tests.Internals {
@@ -11,7 +14,7 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var linqSorted = SampleData.OrderBy(e => e.FirstName).ToList();
 
-            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("FirstName").ToList();
+            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("FirstName", new ModelDescription(typeof(Datum))).ToList();
 
             Assert.Equal(linqSorted, linqBuilderSorted);
         }
@@ -21,7 +24,17 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var linqSorted = SampleData.OrderBy(e => e.Number).ToList();
 
-            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("Number").ToList();
+            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("Number", new ModelDescription(typeof(Datum))).ToList();
+
+            Assert.Equal(linqSorted, linqBuilderSorted);
+        }
+
+        [Fact]
+        public void OrderByPublicNameCompatible()
+        {
+            var linqSorted = SampleData.OrderBy(e => e.InternalName).ToList();
+
+            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("PublicName", new ModelDescription(typeof(Datum))).ToList();
 
             Assert.Equal(linqSorted, linqBuilderSorted);
         }
@@ -31,7 +44,7 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var linqSorted = SampleData.OrderByDescending(e => e.FirstName).ToList();
 
-            var linqBuilderSorted = SampleData.AsQueryable().OrderByDescending("FirstName").ToList();
+            var linqBuilderSorted = SampleData.AsQueryable().OrderByDescending("FirstName", new ModelDescription(typeof(Datum))).ToList();
 
             Assert.Equal(linqSorted, linqBuilderSorted);
         }
@@ -41,7 +54,7 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var linqSorted = SampleData.OrderByDescending(e => e.Number).ToList();
 
-            var linqBuilderSorted = SampleData.AsQueryable().OrderByDescending("Number").ToList();
+            var linqBuilderSorted = SampleData.AsQueryable().OrderByDescending("Number", new ModelDescription(typeof(Datum))).ToList();
 
             Assert.Equal(linqSorted, linqBuilderSorted);
         }
@@ -49,8 +62,8 @@ namespace ExtraDry.Core.Tests.Internals {
         [Fact]
         public void OrderByInvalidNameException()
         {
-            Assert.Throws<DryException>(() => 
-                SampleData.AsQueryable().OrderByDescending("Invalid").ToList()
+            Assert.Throws<DryException>(() =>
+                SampleData.AsQueryable().OrderByDescending("Invalid", new ModelDescription(typeof(Datum))).ToList()
             );
         }
 
@@ -58,8 +71,9 @@ namespace ExtraDry.Core.Tests.Internals {
         public void ThenByCompatible()
         {
             var linqSorted = SampleData.OrderBy(e => e.FirstName).ThenBy(e => e.Number).ToList();
+            var modelDescription = new ModelDescription(typeof(Datum));
 
-            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("FirstName").ThenBy("Number").ToList();
+            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("FirstName", modelDescription).ThenBy("Number", modelDescription).ToList();
 
             Assert.Equal(linqSorted, linqBuilderSorted);
         }
@@ -68,8 +82,9 @@ namespace ExtraDry.Core.Tests.Internals {
         public void ThenByDescendingCompatible()
         {
             var linqSorted = SampleData.OrderByDescending(e => e.FirstName).ThenByDescending(e => e.Number).ToList();
+            var modelDescription = new ModelDescription(typeof(Datum));
 
-            var linqBuilderSorted = SampleData.AsQueryable().OrderByDescending("FirstName").ThenByDescending("Number").ToList();
+            var linqBuilderSorted = SampleData.AsQueryable().OrderByDescending("FirstName", modelDescription).ThenByDescending("Number", modelDescription).ToList();
 
             Assert.Equal(linqSorted, linqBuilderSorted);
         }
@@ -116,6 +131,11 @@ namespace ExtraDry.Core.Tests.Internals {
         }
 
         public class Datum {
+
+            [JsonIgnore]
+            [Key]
+            public int Id { get; set; }
+
             [Filter(FilterType.Equals)]
             public string FirstName { get; set; }
 
@@ -126,10 +146,13 @@ namespace ExtraDry.Core.Tests.Internals {
             public string Keywords { get; set; }
 
             public int Number { get; set; }
+
+            [JsonPropertyName("publicName")]
+            public string InternalName { get; set; }
         }
 
         private readonly List<Datum> SampleData = new() {
-            new Datum { FirstName = "Charlie", LastName = "Coase", Number = 111},
+            new Datum { FirstName = "Charlie", LastName = "Coase", Number = 111 },
             new Datum { FirstName = "Alice", LastName = "Cooper", Number = 333 },
             new Datum { FirstName = "Bob", LastName = "Barker", Number = 222 },
         };

--- a/ExtraDry/ExtraDry.Core.Tests/Internals/LinqBuilderTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Internals/LinqBuilderTests.cs
@@ -1,4 +1,4 @@
-using ExtraDry.Server.Internal;
+﻿using ExtraDry.Server.Internal;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -14,7 +14,7 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var linqSorted = SampleData.OrderBy(e => e.FirstName).ToList();
 
-            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("FirstName", new ModelDescription(typeof(Datum))).ToList();
+            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("FirstName").ToList();
 
             Assert.Equal(linqSorted, linqBuilderSorted);
         }
@@ -24,7 +24,7 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var linqSorted = SampleData.OrderBy(e => e.Number).ToList();
 
-            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("Number", new ModelDescription(typeof(Datum))).ToList();
+            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("Number").ToList();
 
             Assert.Equal(linqSorted, linqBuilderSorted);
         }
@@ -34,7 +34,7 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var linqSorted = SampleData.OrderBy(e => e.InternalName).ToList();
 
-            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("PublicName", new ModelDescription(typeof(Datum))).ToList();
+            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("PublicName").ToList();
 
             Assert.Equal(linqSorted, linqBuilderSorted);
         }
@@ -44,7 +44,7 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var linqSorted = SampleData.OrderByDescending(e => e.FirstName).ToList();
 
-            var linqBuilderSorted = SampleData.AsQueryable().OrderByDescending("FirstName", new ModelDescription(typeof(Datum))).ToList();
+            var linqBuilderSorted = SampleData.AsQueryable().OrderByDescending("FirstName").ToList();
 
             Assert.Equal(linqSorted, linqBuilderSorted);
         }
@@ -54,7 +54,7 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var linqSorted = SampleData.OrderByDescending(e => e.Number).ToList();
 
-            var linqBuilderSorted = SampleData.AsQueryable().OrderByDescending("Number", new ModelDescription(typeof(Datum))).ToList();
+            var linqBuilderSorted = SampleData.AsQueryable().OrderByDescending("Number").ToList();
 
             Assert.Equal(linqSorted, linqBuilderSorted);
         }
@@ -63,7 +63,7 @@ namespace ExtraDry.Core.Tests.Internals {
         public void OrderByInvalidNameException()
         {
             Assert.Throws<DryException>(() =>
-                SampleData.AsQueryable().OrderByDescending("Invalid", new ModelDescription(typeof(Datum))).ToList()
+                SampleData.AsQueryable().OrderByDescending("Invalid").ToList()
             );
         }
 
@@ -71,9 +71,8 @@ namespace ExtraDry.Core.Tests.Internals {
         public void ThenByCompatible()
         {
             var linqSorted = SampleData.OrderBy(e => e.FirstName).ThenBy(e => e.Number).ToList();
-            var modelDescription = new ModelDescription(typeof(Datum));
 
-            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("FirstName", modelDescription).ThenBy("Number", modelDescription).ToList();
+            var linqBuilderSorted = SampleData.AsQueryable().OrderBy("FirstName").ThenBy("Number").ToList();
 
             Assert.Equal(linqSorted, linqBuilderSorted);
         }
@@ -84,7 +83,7 @@ namespace ExtraDry.Core.Tests.Internals {
             var linqSorted = SampleData.OrderByDescending(e => e.FirstName).ThenByDescending(e => e.Number).ToList();
             var modelDescription = new ModelDescription(typeof(Datum));
 
-            var linqBuilderSorted = SampleData.AsQueryable().OrderByDescending("FirstName", modelDescription).ThenByDescending("Number", modelDescription).ToList();
+            var linqBuilderSorted = SampleData.AsQueryable().OrderByDescending("FirstName").ThenByDescending("Number").ToList();
 
             Assert.Equal(linqSorted, linqBuilderSorted);
         }
@@ -96,6 +95,17 @@ namespace ExtraDry.Core.Tests.Internals {
 
             var filterProperty = GetFilterProperty("FirstName");
             var linqBuilderWhere = SampleData.AsQueryable().WhereFilterConditions(new FilterProperty[] { filterProperty }, "firstname:Bob").ToList();
+
+            Assert.Equal(linqWhere, linqBuilderWhere);
+        }
+
+        [Fact]
+        public void SingleEqualsWhereFilterJsonNameCompatible()
+        {
+            var linqWhere = SampleData.Where(e => e.InternalName == "Bobby").ToList();
+            var modelDescription = new ModelDescription(typeof(Datum));
+
+            var linqBuilderWhere = SampleData.AsQueryable().WhereFilterConditions(modelDescription.FilterProperties.ToArray(), "publicname:Bobby").ToList();
 
             Assert.Equal(linqWhere, linqBuilderWhere);
         }
@@ -147,14 +157,15 @@ namespace ExtraDry.Core.Tests.Internals {
 
             public int Number { get; set; }
 
+            [Filter(FilterType.Equals)]
             [JsonPropertyName("publicName")]
             public string InternalName { get; set; }
         }
 
         private readonly List<Datum> SampleData = new() {
-            new Datum { FirstName = "Charlie", LastName = "Coase", Number = 111 },
-            new Datum { FirstName = "Alice", LastName = "Cooper", Number = 333 },
-            new Datum { FirstName = "Bob", LastName = "Barker", Number = 222 },
+            new Datum { FirstName = "Charlie", LastName = "Coase", Number = 111, InternalName = "Chuck" },
+            new Datum { FirstName = "Alice", LastName = "Cooper", Number = 333, InternalName = "Al" },
+            new Datum { FirstName = "Bob", LastName = "Barker", Number = 222, InternalName = "Bobby" },
         };
 
         //private readonly List<Datum> SampleDataWithDuplicateNames = new() {

--- a/ExtraDry/ExtraDry.Core.Tests/Internals/LinqBuilderTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Internals/LinqBuilderTests.cs
@@ -127,7 +127,7 @@ namespace ExtraDry.Core.Tests.Internals {
         {
             var property = typeof(Datum).GetProperty(propertyName);
             var filter = property.GetCustomAttributes(false).First() as FilterAttribute;
-            return new FilterProperty(property, filter);
+            return new FilterProperty(property, filter, property.Name);
         }
 
         public class Datum {

--- a/ExtraDry/ExtraDry.Core.Tests/Server/ExtensionMethods/QueryableExtensionsTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Server/ExtensionMethods/QueryableExtensionsTests.cs
@@ -1,13 +1,12 @@
 ﻿#nullable enable
 
-using ExtraDry.Core;
 using ExtraDry.Server;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using Xunit;
 
-namespace ExtraDry.Blazor.Tests.Core.Models {
+namespace ExtraDry.Core.Tests.Server.ExtensionMethods {
     public class QueryableExtensionsTests {
 
         [Fact]
@@ -19,7 +18,7 @@ namespace ExtraDry.Blazor.Tests.Core.Models {
                 new IdConventionKey { Id = 2 },
             };
             var query = new FilterQuery();
-            
+
             var sorted = list.AsQueryable()
                 .Sort(query)
                 .ToList();

--- a/ExtraDry/ExtraDry.Core.Tests/Server/Internal/ModelDescrptionTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Server/Internal/ModelDescrptionTests.cs
@@ -1,5 +1,8 @@
 ﻿using ExtraDry.Server.Internal;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 using Xunit;
 
 namespace ExtraDry.Core.Tests.Server.Internal {
@@ -7,7 +10,7 @@ namespace ExtraDry.Core.Tests.Server.Internal {
     public class ModelDescrptionTests {
 
         [Fact]
-        public void KeyPropertyIsKeyAttribute()
+        public void StabilizerPropertyIsKeyAttribute()
         {
             var modelDescription = new ModelDescription(typeof(KeyAttributeEntity));
 
@@ -17,7 +20,7 @@ namespace ExtraDry.Core.Tests.Server.Internal {
         }
 
         [Fact]
-        public void KeyPropertyIsIdConvention()
+        public void StabilizerPropertyIsIdConvention()
         {
             var modelDescription = new ModelDescription(typeof(IdConventionEntity));
 
@@ -27,7 +30,7 @@ namespace ExtraDry.Core.Tests.Server.Internal {
         }
 
         [Fact]
-        public void KeyPropertyIsClassNameConvention()
+        public void StabilizerPropertyIsClassNameConvention()
         {
             var modelDescription = new ModelDescription(typeof(ClassNameConventionEntity));
 
@@ -37,12 +40,32 @@ namespace ExtraDry.Core.Tests.Server.Internal {
         }
 
         [Fact]
-        public void KeyPropertyIsMissing()
+        public void StabilizerPropertyIsMissing()
         {
             var exception = Assert.Throws<DryException>(() => new ModelDescription(typeof(NoImplicitStabilizer)));
 
             Assert.NotNull(exception);
             Assert.Equal("Unable to Sort. 0x0F3F241C", exception.UserMessage);
+        }
+
+        [Fact]
+        public void SortPropertiesFiltered()
+        {
+            var modelDescription = new ModelDescription(typeof(SortPropertiesEntity));
+
+            Assert.Equal(2, modelDescription.SortProperties.Count);
+            Assert.Equal("Name", modelDescription.SortProperties[0].ExternalName);
+            Assert.Equal("ExternalName", modelDescription.SortProperties[1].ExternalName);
+        }
+
+        [Fact]
+        public void FilterPropertiesFiltered()
+        {
+            var modelDescription = new ModelDescription(typeof(SortPropertiesEntity));
+
+            Assert.Equal(2, modelDescription.FilterProperties.Count);
+            Assert.Equal("Name", modelDescription.FilterProperties[0].ExternalName);
+            Assert.Equal("ExternalName", modelDescription.FilterProperties[1].ExternalName);
         }
 
         public class KeyAttributeEntity {
@@ -70,6 +93,29 @@ namespace ExtraDry.Core.Tests.Server.Internal {
             public int PrimaryKey { get; set; }
 
             public string Payload { get; set; } = string.Empty;
+        }
+
+        public class SortPropertiesEntity {
+            
+            [Key]
+            public int Key { get; set; }
+
+            [Filter(FilterType.Contains)]
+            public string Name { get; set; }
+
+            [Filter(FilterType.Equals)]
+            [JsonPropertyName("externalName")]
+            public string InternalName { get; set; }
+
+            public object Entity { get; set; }
+
+            public ICollection<object> Collection { get; set; }
+
+            [JsonIgnore]
+            public string Ignored { get; set; }
+
+            [NotMapped]
+            public string NotMapped { get; set; }
         }
     }
 }

--- a/ExtraDry/ExtraDry.Core.Tests/Server/Internal/ModelDescrptionTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Server/Internal/ModelDescrptionTests.cs
@@ -44,10 +44,9 @@ namespace ExtraDry.Core.Tests.Server.Internal {
         {
             var modelDescription = new ModelDescription(typeof(NoImplicitStabilizer));
 
-            var exception = Assert.Throws<DryException>(() => modelDescription.StabilizerProperty);
+            var stabilizerProperty = modelDescription.StabilizerProperty;
 
-            Assert.NotNull(exception);
-            Assert.Equal("Unable to Sort. 0x0F3F241C", exception.UserMessage);
+            Assert.Null(stabilizerProperty);
         }
 
         [Fact]
@@ -55,10 +54,9 @@ namespace ExtraDry.Core.Tests.Server.Internal {
         {
             var modelDescription = new ModelDescription(typeof(CompositeKeyAttributeEntity));
 
-            var exception = Assert.Throws<DryException>(() => modelDescription.StabilizerProperty);
+            var stabilizerProperty = modelDescription.StabilizerProperty;
 
-            Assert.NotNull(exception);
-            Assert.Equal("Unable to Sort. 0x0F3F241D", exception.UserMessage);
+            Assert.Null(stabilizerProperty);
         }
 
         [Fact]

--- a/ExtraDry/ExtraDry.Core.Tests/Server/Internal/ModelDescrptionTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Server/Internal/ModelDescrptionTests.cs
@@ -1,0 +1,75 @@
+﻿using ExtraDry.Server.Internal;
+using System.ComponentModel.DataAnnotations;
+using Xunit;
+
+namespace ExtraDry.Core.Tests.Server.Internal {
+
+    public class ModelDescrptionTests {
+
+        [Fact]
+        public void KeyPropertyIsKeyAttribute()
+        {
+            var modelDescription = new ModelDescription(typeof(KeyAttributeEntity));
+
+            Assert.NotNull(modelDescription);
+            Assert.NotNull(modelDescription.StabilizerProperty);
+            Assert.Equal("PrimaryKey", modelDescription.StabilizerProperty.ExternalName);
+        }
+
+        [Fact]
+        public void KeyPropertyIsIdConvention()
+        {
+            var modelDescription = new ModelDescription(typeof(IdConventionEntity));
+
+            Assert.NotNull(modelDescription);
+            Assert.NotNull(modelDescription.StabilizerProperty);
+            Assert.Equal("Id", modelDescription.StabilizerProperty.ExternalName);
+        }
+
+        [Fact]
+        public void KeyPropertyIsClassNameConvention()
+        {
+            var modelDescription = new ModelDescription(typeof(ClassNameConventionEntity));
+
+            Assert.NotNull(modelDescription);
+            Assert.NotNull(modelDescription.StabilizerProperty);
+            Assert.Equal("ClassNameConventionEntityId", modelDescription.StabilizerProperty.ExternalName);
+        }
+
+        [Fact]
+        public void KeyPropertyIsMissing()
+        {
+            var exception = Assert.Throws<DryException>(() => new ModelDescription(typeof(NoImplicitStabilizer)));
+
+            Assert.NotNull(exception);
+            Assert.Equal("Unable to Sort. 0x0F3F241C", exception.UserMessage);
+        }
+
+        public class KeyAttributeEntity {
+
+            [Key]
+            public int PrimaryKey { get; set; }
+
+            public string Payload { get; set; } = string.Empty;
+
+        }
+
+        public class IdConventionEntity {
+            public int Id { get; set; }
+
+            public string Payload { get; set; } = string.Empty;
+        }
+
+        public class ClassNameConventionEntity {
+            public int ClassNameConventionEntityId { get; set; }
+
+            public string Payload { get; set; } = string.Empty;
+        }
+
+        public class NoImplicitStabilizer {
+            public int PrimaryKey { get; set; }
+
+            public string Payload { get; set; } = string.Empty;
+        }
+    }
+}

--- a/ExtraDry/ExtraDry.Core.Tests/Server/Internal/ModelDescrptionTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Server/Internal/ModelDescrptionTests.cs
@@ -42,10 +42,23 @@ namespace ExtraDry.Core.Tests.Server.Internal {
         [Fact]
         public void StabilizerPropertyIsMissing()
         {
-            var exception = Assert.Throws<DryException>(() => new ModelDescription(typeof(NoImplicitStabilizer)));
+            var modelDescription = new ModelDescription(typeof(NoImplicitStabilizer));
+
+            var exception = Assert.Throws<DryException>(() => modelDescription.StabilizerProperty);
 
             Assert.NotNull(exception);
             Assert.Equal("Unable to Sort. 0x0F3F241C", exception.UserMessage);
+        }
+
+        [Fact]
+        public void StabilizerPropertyIsCompositeKey()
+        {
+            var modelDescription = new ModelDescription(typeof(CompositeKeyAttributeEntity));
+
+            var exception = Assert.Throws<DryException>(() => modelDescription.StabilizerProperty);
+
+            Assert.NotNull(exception);
+            Assert.Equal("Unable to Sort. 0x0F3F241D", exception.UserMessage);
         }
 
         [Fact]
@@ -93,6 +106,18 @@ namespace ExtraDry.Core.Tests.Server.Internal {
             public int PrimaryKey { get; set; }
 
             public string Payload { get; set; } = string.Empty;
+        }
+
+        public class CompositeKeyAttributeEntity {
+
+            [Key]
+            public int PrimaryKey { get; set; }
+
+            [Key]
+            public int SecondaryKey { get; set; }
+
+            public string Payload { get; set; } = string.Empty;
+
         }
 
         public class SortPropertiesEntity {

--- a/ExtraDry/ExtraDry.Core/AssemblyInfo.cs
+++ b/ExtraDry/ExtraDry.Core/AssemblyInfo.cs
@@ -2,4 +2,5 @@
 
 [assembly: InternalsVisibleTo("ExtraDry.Tests")]
 [assembly: InternalsVisibleTo("ExtraDry.Core.Tests")]
+[assembly: InternalsVisibleTo("ExtraDry.Swashbuckle")]
 

--- a/ExtraDry/ExtraDry.Core/Server/ExtensionMethods/QueryableExtensions.cs
+++ b/ExtraDry/ExtraDry.Core/Server/ExtensionMethods/QueryableExtensions.cs
@@ -13,6 +13,8 @@ namespace ExtraDry.Server {
     /// A very lightweight dynamic linq builder, just enough to satisfy needs of filtering, sorting and paging API result sets.
     /// </summary>
     public static class QueryableExtensions {
+        private const string MissingStabilizerErrorMessage = "Sort requires that a single EF key is uniquely defined to stabalize the sort, even if another sort property is present.  Use a single unique key following EF conventions or specify a Stabilizer in the FilterQuery.";
+        private const string SortErrorUserMessage = "Unable to Sort. 0x0F3F241C";
 
         /// <summary>
         /// Given a `PageQuery`, dynamically constructs an expression query that applies the indicated filtering, sorting, and paging.
@@ -95,6 +97,9 @@ namespace ExtraDry.Server {
             var actualAscending = token?.Ascending ?? ascending ?? true;
             var query = source;
             var modelDescription = new ModelDescription(typeof(T));
+            if(modelDescription.StabilizerProperty == default) {
+                throw new DryException(MissingStabilizerErrorMessage, SortErrorUserMessage);
+            }
             if(!string.IsNullOrWhiteSpace(actualSort)) {
                 query = actualAscending ? 
                     query.OrderBy(actualSort).ThenBy(modelDescription.StabilizerProperty.ExternalName) : 

--- a/ExtraDry/ExtraDry.Core/Server/ExtensionMethods/QueryableExtensions.cs
+++ b/ExtraDry/ExtraDry.Core/Server/ExtensionMethods/QueryableExtensions.cs
@@ -89,7 +89,6 @@ namespace ExtraDry.Server {
         /// <param name="source">The queryable source, typically from EF, this is from `DbSet.AsQueryable()`</param>
         /// <param name="sort">The name of the property to sort by (optional, case insensitive)</param>
         /// <param name="ascending">Indicates if the order is ascending or not (optional, default true)</param>
-        /// <param name="stabilizer">The name of a unique property to ensure paging works, use monotonically increasing value such as `int Identity` or created timestamp (required, case insensitive)</param>
         /// <param name="continuationToken">If this is not a new request, the token passed back from the previous request to maintain stability (optional)</param>
         internal static IQueryable<T> Sort<T>(this IQueryable<T> source, string? sort, bool? ascending, string? continuationToken, ModelDescription modelDescription)
         {

--- a/ExtraDry/ExtraDry.Core/Server/Internal/FilterProperty.cs
+++ b/ExtraDry/ExtraDry.Core/Server/Internal/FilterProperty.cs
@@ -8,11 +8,11 @@ namespace ExtraDry.Server.Internal {
     /// </summary>
     internal class FilterProperty {
 
-        public FilterProperty(PropertyInfo property, FilterAttribute filter, string externalName)
+        public FilterProperty(PropertyInfo property, FilterAttribute filter, string? externalName = null)
         {
             Property = property;
             Filter = filter;
-            ExternalName = externalName;
+            ExternalName = externalName ?? property.Name;
         }
 
         public PropertyInfo Property { get; set; }

--- a/ExtraDry/ExtraDry.Core/Server/Internal/FilterProperty.cs
+++ b/ExtraDry/ExtraDry.Core/Server/Internal/FilterProperty.cs
@@ -8,15 +8,18 @@ namespace ExtraDry.Server.Internal {
     /// </summary>
     internal class FilterProperty {
 
-        public FilterProperty(PropertyInfo property, FilterAttribute filter)
+        public FilterProperty(PropertyInfo property, FilterAttribute filter, string externalName)
         {
             Property = property;
             Filter = filter;
+            ExternalName = externalName;
         }
 
         public PropertyInfo Property { get; set; }
 
         public FilterAttribute Filter { get; set; }
+
+        public string ExternalName { get; }
 
     }
 }

--- a/ExtraDry/ExtraDry.Core/Server/Internal/LinqBuilder.cs
+++ b/ExtraDry/ExtraDry.Core/Server/Internal/LinqBuilder.cs
@@ -15,41 +15,42 @@ namespace ExtraDry.Server.Internal {
         /// <summary>
         /// Sorts the elements of the sequence according to a key which is provided by name instead of a lambda.
         /// </summary>
-        public static IOrderedQueryable<T> OrderBy<T>(this IQueryable<T> source, string property, ModelDescription modelDescription)
+        public static IOrderedQueryable<T> OrderBy<T>(this IQueryable<T> source, string property)
         {
-            return ApplyOrder(source, property, OrderType.OrderBy, modelDescription);
+            return ApplyOrder(source, property, OrderType.OrderBy);
         }
 
         /// <summary>
         /// Sorts the elements of the sequence, in descending order, according to a key which is provided by name instead of a lambda.
         /// </summary>
-        public static IOrderedQueryable<T> OrderByDescending<T>(this IQueryable<T> source, string property, ModelDescription modelDescription)
+        public static IOrderedQueryable<T> OrderByDescending<T>(this IQueryable<T> source, string property)
         {
-            return ApplyOrder(source, property, OrderType.OrderByDescending, modelDescription);
+            return ApplyOrder(source, property, OrderType.OrderByDescending);
         }
 
         /// <summary>
         /// Performs a subsequent ordering of a sequence according to a key which is provided by name instead of a lambda.
         /// </summary>
-        public static IOrderedQueryable<T> ThenBy<T>(this IOrderedQueryable<T> source, string property, ModelDescription modelDescription)
+        public static IOrderedQueryable<T> ThenBy<T>(this IOrderedQueryable<T> source, string property)
         {
-            return ApplyOrder(source, property, OrderType.ThenBy, modelDescription);
+            return ApplyOrder(source, property, OrderType.ThenBy);
         }
 
         /// <summary>
         /// Performs a subsequent ordering of a sequence, in descending order, according to a key which is provided by name instead of a lambda.
         /// </summary>
-        public static IOrderedQueryable<T> ThenByDescending<T>(this IOrderedQueryable<T> source, string property, ModelDescription modelDescription)
+        public static IOrderedQueryable<T> ThenByDescending<T>(this IOrderedQueryable<T> source, string property)
         {
-            return ApplyOrder(source, property, OrderType.ThenByDescending, modelDescription);
+            return ApplyOrder(source, property, OrderType.ThenByDescending);
         }
 
         /// <summary>
         /// Applies LINQ method by property name and method name instead of using Method and Lambda.
         /// </summary>
         /// <remarks>see https://stackoverflow.com/questions/41244/dynamic-linq-orderby-on-ienumerablet-iqueryablet</remarks>
-        private static IOrderedQueryable<T> ApplyOrder<T>(IQueryable<T> source, string property, OrderType methodType, ModelDescription modelDescription)
+        private static IOrderedQueryable<T> ApplyOrder<T>(IQueryable<T> source, string property, OrderType methodType)
         {
+            var modelDescription = new ModelDescription(typeof(T));
             string[] props = property.Split('.');
             var type = typeof(T);
             var arg = Expression.Parameter(type, "x");
@@ -88,7 +89,7 @@ namespace ExtraDry.Server.Internal {
             var terms = new List<Expression>();
             var filter = FilterParser.Parse(filterQuery);
             foreach(var rule in filter.Rules) {
-                var property = filterProperties.FirstOrDefault(e => string.Equals(e.Property.Name, rule.PropertyName, StringComparison.OrdinalIgnoreCase));
+                var property = filterProperties.FirstOrDefault(e => string.Equals(e.ExternalName, rule.PropertyName, StringComparison.OrdinalIgnoreCase));
                 if(rule.PropertyName == "*") {
                     var keywords = new List<Expression>();
                     foreach(var filterProperty in filterProperties) {
@@ -122,9 +123,12 @@ namespace ExtraDry.Server.Internal {
                     throw new DryException($"Could not find property '{rule.PropertyName}' requested in filter query.  No property had with that name has a [Filter] attribute applied to it.", "Unable to apply filter. 0x0F4F4931");
                 }
             }
-            var cnf = AllOf(terms.ToArray());
-            var lambda = Expression.Lambda<Func<T, bool>>(cnf, param);
-            return source.Where(lambda);
+            if(terms.Any()) {
+                var cnf = AllOf(terms.ToArray());
+                var lambda = Expression.Lambda<Func<T, bool>>(cnf, param);
+                return source.Where(lambda);
+            }
+            return source;
         }
 
         private static void AddTerms(ParameterExpression param, List<Expression> terms, FilterRule rule, FilterProperty property)
@@ -201,7 +205,7 @@ namespace ExtraDry.Server.Internal {
                 }
             }
             catch {
-                throw new DryException($"Filter expression '{value}' was not of the correct type.");
+                throw new DryException($"Filter expression '{value}' was not of the correct type.", "Unable to apply filter. 0x0F4A10KL");
             }
         }
 
@@ -224,9 +228,9 @@ namespace ExtraDry.Server.Internal {
         private static MethodInfo StringStartsWithMethod => typeof(string).GetMethod(nameof(string.StartsWith), new[] { typeof(string) })!;
 
         private enum OrderType {
-            OrderBy, 
-            ThenBy, 
-            OrderByDescending, 
+            OrderBy,
+            ThenBy,
+            OrderByDescending,
             ThenByDescending,
         }
 

--- a/ExtraDry/ExtraDry.Core/Server/Internal/LinqBuilder.cs
+++ b/ExtraDry/ExtraDry.Core/Server/Internal/LinqBuilder.cs
@@ -57,7 +57,7 @@ namespace ExtraDry.Server.Internal {
             Expression expr = arg;
             foreach(string prop in props) {
                 var pi = modelDescription.SortProperties.FirstOrDefault(sortProp => string.Equals(sortProp.ExternalName, prop, StringComparison.OrdinalIgnoreCase))?.Property
-                    ?? (modelDescription.StabilizerProperty.ExternalName.ToLower() == prop.ToLower() 
+                    ?? (modelDescription.StabilizerProperty?.ExternalName.ToLower() == prop.ToLower() 
                             ? modelDescription.StabilizerProperty.Property 
                             : throw new DryException($"Could not find sort property `{prop}`", "Could not apply requested sort"));
                 expr = Expression.Property(expr, pi);

--- a/ExtraDry/ExtraDry.Core/Server/Internal/LinqBuilder.cs
+++ b/ExtraDry/ExtraDry.Core/Server/Internal/LinqBuilder.cs
@@ -56,7 +56,7 @@ namespace ExtraDry.Server.Internal {
             var arg = Expression.Parameter(type, "x");
             Expression expr = arg;
             foreach(string prop in props) {
-                var pi = modelDescription.SortProperties.FirstOrDefault(sortProp => sortProp.ExternalName.ToLower() == prop.ToLower())?.Property
+                var pi = modelDescription.SortProperties.FirstOrDefault(sortProp => string.Equals(sortProp.ExternalName, prop, StringComparison.OrdinalIgnoreCase))?.Property
                     ?? (modelDescription.StabilizerProperty.ExternalName.ToLower() == prop.ToLower() 
                             ? modelDescription.StabilizerProperty.Property 
                             : throw new DryException($"Could not find sort property `{prop}`", "Could not apply requested sort"));

--- a/ExtraDry/ExtraDry.Core/Server/Internal/ModelDescription.cs
+++ b/ExtraDry/ExtraDry.Core/Server/Internal/ModelDescription.cs
@@ -22,7 +22,7 @@ namespace ExtraDry.Server.Internal {
 
         public Collection<FilterProperty> FilterProperties { get; } = new Collection<FilterProperty>();
         public Collection<SortProperty> SortProperties { get; } = new Collection<SortProperty>();
-        public SortProperty StabilizerProperty { get; private set; }
+        public SortProperty StabilizerProperty { get; private set; } = null!;
 
         private void GetReflectedModelProperties(Type modelType)
         {
@@ -33,7 +33,7 @@ namespace ExtraDry.Server.Internal {
 
                 var filter = property.GetCustomAttribute<FilterAttribute>();
                 if(filter != null) {
-                    FilterProperties.Add(new FilterProperty(property, filter));
+                    FilterProperties.Add(new FilterProperty(property, filter, externalName));
                 }
 
                 if(IsSortable(property)) {
@@ -66,7 +66,7 @@ namespace ExtraDry.Server.Internal {
         {
             var propAttrib = property.GetCustomAttributes().FirstOrDefault(e => e.GetType().Name == "JsonPropertyNameAttribute");
             if(propAttrib != default && propAttrib is JsonPropertyNameAttribute jsonPropAttrib) {
-                return jsonPropAttrib.Name;
+                return $"{jsonPropAttrib.Name[..1].ToUpperInvariant()}{jsonPropAttrib.Name[1..]}";
             }
             return property.Name;
         }

--- a/ExtraDry/ExtraDry.Core/Server/Internal/ModelDescription.cs
+++ b/ExtraDry/ExtraDry.Core/Server/Internal/ModelDescription.cs
@@ -1,11 +1,19 @@
-﻿using ExtraDry.Core;
+﻿#nullable enable
+
+using ExtraDry.Core;
 using System;
 using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Reflection;
+using System.Text.Json.Serialization;
 
 namespace ExtraDry.Server.Internal {
 
     internal class ModelDescription {
+        private const string DuplicateKeyMessage = "Sort requires that a single EF key is well defined to stabalize the sort, composite keys are not supported.  Manually specify a Stabilizer in the FilterQuery, or use a single [Key] attribute.";
+        private const string MissingStabilizerMessage = "Sort requires that an EF key is uniquely defined to stabalize the sort, even if another sort property is present.  Create a unique key following EF conventions or specify a Stabilizer in the FilterQuery.";
+        private const string UserMessage = "Unable to Sort. {0}";
 
         public ModelDescription(Type modelType)
         {
@@ -13,17 +21,69 @@ namespace ExtraDry.Server.Internal {
         }
 
         public Collection<FilterProperty> FilterProperties { get; } = new Collection<FilterProperty>();
+        public Collection<SortProperty> SortProperties { get; } = new Collection<SortProperty>();
+        public SortProperty StabilizerProperty { get; private set; }
 
         private void GetReflectedModelProperties(Type modelType)
         {
             var properties = modelType.GetProperties();
+            SortProperty? stabilizerPropertyByConvention = default;
             foreach(var property in properties) {
+                var externalName = ExternalName(property);
+
                 var filter = property.GetCustomAttribute<FilterAttribute>();
                 if(filter != null) {
                     FilterProperties.Add(new FilterProperty(property, filter));
                 }
+
+                if(IsSortable(property)) {
+                    SortProperties.Add(new SortProperty(property, externalName));
+                }
+
+                var keyProperty = property.GetCustomAttribute<KeyAttribute>();
+                if(keyProperty != default) {
+                    if(StabilizerProperty == default) {
+                        StabilizerProperty = new SortProperty(property, externalName);
+                    }
+                    else {
+                        throw new DryException(DuplicateKeyMessage, string.Format(UserMessage, "0x0F3F241D"));
+                    }
+                }
+
+                if(property.Name == "Id") {
+                    stabilizerPropertyByConvention = new SortProperty(property, externalName);
+                }
+                else if(stabilizerPropertyByConvention == default && property.Name == $"{modelType.Name}Id") {
+                    stabilizerPropertyByConvention = new SortProperty(property, externalName);
+                }
+            }
+            if(StabilizerProperty == default) {
+                StabilizerProperty = stabilizerPropertyByConvention ?? throw new DryException(MissingStabilizerMessage, string.Format(UserMessage, "0x0F3F241C"));
             }
         }
 
+        private static string ExternalName(PropertyInfo property)
+        {
+            var propAttrib = property.GetCustomAttributes().FirstOrDefault(e => e.GetType().Name == "JsonPropertyNameAttribute");
+            if(propAttrib != default && propAttrib is JsonPropertyNameAttribute jsonPropAttrib) {
+                return jsonPropAttrib.Name;
+            }
+            return property.Name;
+        }
+
+        public static bool IsSortable(PropertyInfo prop)
+        {
+            // By name to avoid having to take dependency on EF and/or Newtonsoft.
+            var disqualifyingAttributes = new string[] { "JsonIgnoreAttribute", "NotMappedAttribute", "KeyAttribute" };
+            var ignore = prop.GetCustomAttributes().Any(e => disqualifyingAttributes.Any(f => f == e.GetType().Name));
+            if(prop.Name == "Id" || prop.Name == $"{prop.DeclaringType?.Name}Id") {
+                // EF convention for Key
+                ignore = true;
+            }
+            if(!ignore && !prop.PropertyType.IsValueType && prop.PropertyType != typeof(string)) {
+                ignore = true;
+            }
+            return !ignore;
+        }
     }
 }

--- a/ExtraDry/ExtraDry.Core/Server/Internal/ModelDescription.cs
+++ b/ExtraDry/ExtraDry.Core/Server/Internal/ModelDescription.cs
@@ -11,10 +11,6 @@ using System.Text.Json.Serialization;
 namespace ExtraDry.Server.Internal {
 
     internal class ModelDescription {
-        private const string DuplicateKeyMessage = "Sort requires that a single EF key is well defined to stabalize the sort, composite keys are not supported.  Manually specify a Stabilizer in the FilterQuery, or use a single [Key] attribute.";
-        private const string MissingStabilizerMessage = "Sort requires that an EF key is uniquely defined to stabalize the sort, even if another sort property is present.  Create a unique key following EF conventions or specify a Stabilizer in the FilterQuery.";
-        private const string UserMessage = "Unable to Sort. {0}";
-
         private SortProperty? stabilizerProperty = null;
         private bool multipleStabilizerProperties;
 
@@ -26,18 +22,7 @@ namespace ExtraDry.Server.Internal {
         public Collection<FilterProperty> FilterProperties { get; } = new Collection<FilterProperty>();
         public Collection<SortProperty> SortProperties { get; } = new Collection<SortProperty>();
 
-        public SortProperty StabilizerProperty {
-            get {
-                if(stabilizerProperty == null) {
-                    throw new DryException(MissingStabilizerMessage, string.Format(UserMessage, "0x0F3F241C"));
-                }
-                if(multipleStabilizerProperties) {
-
-                    throw new DryException(DuplicateKeyMessage, string.Format(UserMessage, "0x0F3F241D"));
-                }
-                return stabilizerProperty;
-            }
-        }
+        public SortProperty? StabilizerProperty => multipleStabilizerProperties ? null : stabilizerProperty;
 
         private void GetReflectedModelProperties(Type modelType)
         {

--- a/ExtraDry/ExtraDry.Core/Server/Internal/SortProperty.cs
+++ b/ExtraDry/ExtraDry.Core/Server/Internal/SortProperty.cs
@@ -1,0 +1,16 @@
+﻿using System.Linq;
+using System.Reflection;
+
+namespace ExtraDry.Server.Internal {
+
+    internal class SortProperty {
+        public SortProperty(PropertyInfo property, string externalName)
+        {
+            Property = property;
+            ExternalName = externalName;
+        }
+
+        public PropertyInfo Property { get; }
+        public string ExternalName { get; }
+    }
+}


### PR DESCRIPTION
- Moved the reflection logic for determining the Sort and Filter properties into `ModelDescription`.
- `ModelDescription` now includes a collection of `SortProperty` objects and a `StabilizerProperty` to make handling sorting easier.
- Sort properties now exclude properties that have `JsonIgnore`, `NotMapped` or `Key` attributes; as well as properties that are collections or objects.
- Sort and Filter now handle properties using `JsonPropertyName` attribute.
- Swashbuckle documentation uses `ModelDescription` to determine Sort and Filter properties.
- Some small bug fixes.