### PR TITLE
Make the problem details title configurable via extra dry options.

### DIFF
--- a/ExtraDry/ExtraDry.Server/AuthorizationResponse.cs
+++ b/ExtraDry/ExtraDry.Server/AuthorizationResponse.cs
@@ -20,7 +20,7 @@ public class AuthorizationResponse {
         await next(context);
 
         if(context.Response.StatusCode == (int)HttpStatusCode.Forbidden) {
-            ProblemDetailsResponse.RewriteResponse(context, HttpStatusCode.Forbidden, options.ForbiddenMessage);
+            ProblemDetailsResponse.RewriteResponse(context, HttpStatusCode.Forbidden, options.ForbiddenTitle, options.ForbiddenMessage);
         }
     }
 }

--- a/ExtraDry/ExtraDry.Server/ExtraDryOptions.cs
+++ b/ExtraDry/ExtraDry.Server/ExtraDryOptions.cs
@@ -2,5 +2,7 @@
 
 public class ExtraDryOptions {
 
+    public string? ForbiddenTitle { get; set; }
+
     public string? ForbiddenMessage { get; set; }
 }

--- a/ExtraDry/ExtraDry.Server/ProblemDetailsResponse.cs
+++ b/ExtraDry/ExtraDry.Server/ProblemDetailsResponse.cs
@@ -13,10 +13,10 @@ public static class ProblemDetailsResponse {
         RewriteResponse(context.HttpContext, context.Exception.GetType().Name, (int)httpStatusCode, context.Exception.Message, details);
     }
 
-    internal static void RewriteResponse(HttpContext httpContext, HttpStatusCode httpStatusCode, string? details = null)
+    internal static void RewriteResponse(HttpContext httpContext, HttpStatusCode httpStatusCode, string? title = null, string? details = null)
     {
         string statusCode = httpStatusCode.ToString();
-        RewriteResponse(httpContext, statusCode.ToLower(), httpContext.Response.StatusCode, statusCode, details);
+        RewriteResponse(httpContext, statusCode.ToLower(), httpContext.Response.StatusCode, title ?? statusCode, details);
     }
 
     private static void RewriteResponse(HttpContext httpContext, string problem, int code, string title, string? details = null)


### PR DESCRIPTION
This allows the consumer to set the `Title` of the `ProblemDetails` returned as part of the 403 Forbidden response.  Usage is:

``` C#
public void ConfigureServices(IServiceCollection services) {
    ...
    services.AddAuthorizationResponse(options => {
        options.ForbiddenTitle = "You're not authorized to access this resource.";
    });
    ...
}
```