### PR TITLE
Add ResourceReference to Open API document schema.

### DIFF
--- a/ExtraDry/ExtraDry.Swashbuckle/Filters/ResourceReferenceSchemaFilter.cs
+++ b/ExtraDry/ExtraDry.Swashbuckle/Filters/ResourceReferenceSchemaFilter.cs
@@ -20,6 +20,12 @@ public class ResourceReferenceSchemaFilter : IDocumentFilter {
 
     private void RewriteResourceReferenceTypes(OpenApiDocument swaggerDoc, DocumentFilterContext context)
     {
+        /*
+         *  Loop through the schemas rewriting property types to a corresponding resource reference 
+         *  type where needed. When adding a resource reference type generate a schema for it, if it 
+         *  doesn't already exist. The `GenerateSchema` method adds the schema to the collection by 
+         *  default, using a `for` loop will avoid any errors due to the collection being changed.
+         */
         for(int i = 0; i < swaggerDoc.Components.Schemas.Count; i++) {
             var schema = swaggerDoc.Components.Schemas.ElementAtOrDefault(i);
             foreach(var property in schema.Value.Properties) {

--- a/ExtraDry/ExtraDry.Swashbuckle/Filters/ResourceReferenceSchemaFilter.cs
+++ b/ExtraDry/ExtraDry.Swashbuckle/Filters/ResourceReferenceSchemaFilter.cs
@@ -24,10 +24,11 @@ public class ResourceReferenceSchemaFilter : IDocumentFilter {
          *  Loop through the schemas rewriting property types to a corresponding resource reference 
          *  type where needed. When adding a resource reference type generate a schema for it, if it 
          *  doesn't already exist. The `GenerateSchema` method adds the schema to the collection by 
-         *  default, using a `for` loop will avoid any errors due to the collection being changed.
+         *  default, using a clone of the collection will avoid any errors due to the collection 
+         *  being changed.
          */
-        for(int i = 0; i < swaggerDoc.Components.Schemas.Count; i++) {
-            var schema = swaggerDoc.Components.Schemas.ElementAtOrDefault(i);
+        var existingSchemas = swaggerDoc.Components.Schemas.ToList();
+        foreach (var schema in existingSchemas) { 
             foreach(var property in schema.Value.Properties) {
                 var qualifiedName = $"{schema.Key}.{property.Key}";
                 if(typeRewrites.TryGetValue(qualifiedName, out var rewriteType)) {
@@ -80,7 +81,7 @@ public class ResourceReferenceSchemaFilter : IDocumentFilter {
             }
         }
     }
-
+    
     /// <summary>
     /// This method is borrowed from Swashbuckle.AspNetCore.SwaggerGen to 
     /// ensure that the reference names we use are the same as the one's 

--- a/ExtraDry/Sample.Shared/Entitites/Region.cs
+++ b/ExtraDry/Sample.Shared/Entitites/Region.cs
@@ -26,6 +26,7 @@ public class Region : TaxonomyEntity<Region>, ITaxonomyEntity, IValidatableObjec
     public RegionLevel Level { get; set; }
 
     [NotMapped]
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     [JsonConverter(typeof(ResourceReferenceConverter<Region>))]
     public override Region? Parent { get => base.Parent; set => base.Parent = value; }
 


### PR DESCRIPTION
When updating the Open API Document to add a typed resource reference and the associated schema.

As an example, a `Region` has a property named `Parent`, of type `Region` that is being converted to a `ResourceReference<Region>`.  When the documentation is created the `Region.Parent` property will reference a `RegionResourceReference`, and a schema for `RegionResourceReference` will have been added.