### PR TITLE
Feature/fix taxonomy bugs

### DIFF
--- a/ExtraDry/ExtraDry.Core/Models/TaxonomyEntity.cs
+++ b/ExtraDry/ExtraDry.Core/Models/TaxonomyEntity.cs
@@ -17,7 +17,7 @@ public abstract class TaxonomyEntity<T> where T : TaxonomyEntity<T>, ITaxonomyEn
                 throw new InvalidOperationException("Parent must be at a higher level than current entity.");
             }
             Ancestors.Clear();
-            Ancestors.AddRange(parent.Ancestors);
+            Ancestors.AddRange(parent.Ancestors.Where(a => a.Uuid != parent.Uuid));
             Ancestors.Add(parent);
         }
         if(this is T self) {
@@ -47,7 +47,7 @@ public abstract class TaxonomyEntity<T> where T : TaxonomyEntity<T>, ITaxonomyEn
     private T? parent;
 
     /// <summary>
-    /// The set of all ancestors for this entity (does not include current entity).
+    /// The set of all ancestors for this entity.
     /// </summary>
     /// <remarks>
     /// This works with `Descendants` and auto-creation of join tables in EF to create a tree Closure table.
@@ -56,7 +56,7 @@ public abstract class TaxonomyEntity<T> where T : TaxonomyEntity<T>, ITaxonomyEn
     public List<T> Ancestors { get; set; } = new();
 
     /// <summary>
-    /// The set of all descendants for this entity (does not include current entity).
+    /// The set of all descendants for this entity.
     /// </summary>
     /// <remarks>
     /// This works with `Ancestors` and auto-creation of join tables in EF to create a tree Closure table.

--- a/ExtraDry/ExtraDry.Core/Models/TaxonomyEntity.cs
+++ b/ExtraDry/ExtraDry.Core/Models/TaxonomyEntity.cs
@@ -17,8 +17,7 @@ public abstract class TaxonomyEntity<T> where T : TaxonomyEntity<T>, ITaxonomyEn
                 throw new InvalidOperationException("Parent must be at a higher level than current entity.");
             }
             Ancestors.Clear();
-            Ancestors.AddRange(parent.Ancestors.Where(a => a.Uuid != parent.Uuid));
-            Ancestors.Add(parent);
+            Ancestors.AddRange(parent.Ancestors);
         }
         if(this is T self) {
             Ancestors.Add(self);

--- a/ExtraDry/Sample.Data/Extensions/TaxonomyExtensions.cs
+++ b/ExtraDry/Sample.Data/Extensions/TaxonomyExtensions.cs
@@ -1,48 +1,39 @@
-﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Newtonsoft.Json.Linq;
-using System;
-using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
-using System.Text;
-using Microsoft.EntityFrameworkCore.Storage;
+﻿namespace Sample.Data; 
+public static class TaxonomyExtensions {
+    /// <summary>
+    /// Moves a subtree from one point in the heirarchy to another.
+    /// </summary>
+    /// <remarks>
+    /// This does not use entity tracking and does a bulk-update to the database.It will participate in enclosing transactions and care should be taken that the Ancestors and Descendants are not otherwise changed in the same transaction.
+    /// </remarks>
+    public static async Task MoveSubtree(this ITaxonomyEntity subtreeRootToMove, ITaxonomyEntity newParent, DbContext context)
+    {
+        // Check that the new parent is at the same strata level as the current parent.
+        if(subtreeRootToMove.Strata != newParent.Strata + 1) {
+            throw new ArgumentException("Moving the subtree cannot change it's strata level");
+        }
+        if(context.ChangeTracker.Entries().Any(e => e.State != EntityState.Unchanged)) {
+            throw new ArgumentException("Moving the subtree needs to happen in isolation from all other changes.");
+        }
+        if(context.Database.CurrentTransaction == null) {
+            throw new ArgumentException("This method must be called from within a transaction.");
+        }
 
-namespace Sample.Data {
-    public static class TaxonomyExtensions {
-        /// <summary>
-        /// Moves a subtree from one point in the heirarchy to another.
-        /// </summary>
-        /// <remarks>
-        /// This does not use entity tracking and does a bulk-update to the database.It will participate in enclosing transactions and care should be taken that the Ancestors and Descendants are not otherwise changed in the same transaction.
-        /// </remarks>
-        public static async Task MoveSubtree(this ITaxonomyEntity subtreeRootToMove, ITaxonomyEntity newParent, DbContext context)
-        {
-            // Check that the new parent is at the same strata level as the current parent.
-            if(subtreeRootToMove.Strata != newParent.Strata + 1) {
-                throw new ArgumentException("Moving the subtree cannot change it's strata level");
-            }
-            if(context.ChangeTracker.Entries().Any(e => e.State != EntityState.Unchanged)) {
-                throw new ArgumentException("Moving the subtree needs to happen in isolation from all other changes.");
-            }
-            if(context.Database.CurrentTransaction == null) {
-                throw new ArgumentException("This method must be called from within a transaction.");
-            }
+        // This should align with the name of the closure table due to EF convention. eg. Region -> RegionRegion, Location -> LocationLocation
+        var closureTableName = $"[{subtreeRootToMove.GetType().Name}{subtreeRootToMove.GetType().Name}]";
 
-            // This should align with the name of the closure table due to EF convention. eg. Region -> RegionRegion, Location -> LocationLocation
-            var closureTableName = $"[{subtreeRootToMove.GetType().Name}{subtreeRootToMove.GetType().Name}]";
-
-            // Query based off the closure table move-subtree queries as found in the book SQL Antipatterns by Bill Karwin
-            // First step deletes references from the super tree to items within the subtree, retaining the self-reference of the root node.
-            await context.Database.ExecuteSqlRawAsync($@"DELETE FROM {closureTableName}
+        // Query based off the closure table move-subtree queries as found in the book SQL Antipatterns by Bill Karwin
+        // First step deletes references from the super tree to items within the subtree, retaining the self-reference of the root node.
+        await context.Database.ExecuteSqlRawAsync($@"DELETE FROM {closureTableName}
 WHERE​ DescendantsId ​IN​ (​SELECT DescendantsId FROM​ {closureTableName} WHERE​ AncestorsId = {subtreeRootToMove.Id})
 AND​ AncestorsId ​IN​ (​SELECT​ AncestorsId FROM​ {closureTableName} ​WHERE DescendantsId = {subtreeRootToMove.Id} ​AND​ AncestorsId != DescendantsId );");
 
-            // Then we insert to the new location, adding links from the items in the subtree to the items in the new parent ancestor path.
-            await context.Database.ExecuteSqlRawAsync($@"INSERT INTO {closureTableName} (AncestorsId, DescendantsId)
+        // Then we insert to the new location, adding links from the items in the subtree to the items in the new parent ancestor path.
+        await context.Database.ExecuteSqlRawAsync($@"INSERT INTO {closureTableName} (AncestorsId, DescendantsId)
 SELECT supertree.AncestorsId, subtree.DescendantsId
 FROM {closureTableName} supertree
 	CROSS JOIN {closureTableName} subtree
 WHERE supertree.DescendantsId = {newParent.Id}
 	and subtree.AncestorsId = {subtreeRootToMove.Id}");
-        }
     }
 }

--- a/ExtraDry/Sample.Data/Extensions/TaxonomyExtensions.cs
+++ b/ExtraDry/Sample.Data/Extensions/TaxonomyExtensions.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
 using System.Text;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Sample.Data {
     public static class TaxonomyExtensions {
@@ -42,7 +43,6 @@ FROM {closureTableName} supertree
 	CROSS JOIN {closureTableName} subtree
 WHERE supertree.DescendantsId = {newParent.Id}
 	and subtree.AncestorsId = {subtreeRootToMove.Id}");
-
         }
     }
 }

--- a/ExtraDry/Sample.Data/SampleContextFactory.cs
+++ b/ExtraDry/Sample.Data/SampleContextFactory.cs
@@ -29,7 +29,7 @@ public class SampleDbContextFactory : IDesignTimeDbContextFactory<SampleContext>
     {
         var builder = new DbContextOptionsBuilder<SampleContext>();
         var connectionString = Configuration.GetConnectionString("SampleContext") ??
-            @"Server=(localdb)\\mssqllocaldb;Database=ExtraDryIntegrationTests;Trusted_Connection=True;";
+            @"Server=(localdb)\mssqllocaldb;Database=ExtraDrySample;Trusted_Connection=True;";
         builder.UseSqlServer(connectionString);
         return new SampleContext(builder.Options);
     }

--- a/ExtraDry/Sample.Data/SampleContextFactory.cs
+++ b/ExtraDry/Sample.Data/SampleContextFactory.cs
@@ -29,7 +29,7 @@ public class SampleDbContextFactory : IDesignTimeDbContextFactory<SampleContext>
     {
         var builder = new DbContextOptionsBuilder<SampleContext>();
         var connectionString = Configuration.GetConnectionString("SampleContext") ??
-            @"Server=(localdb)\mssqllocaldb;Database=ExtraDrySample;Trusted_Connection=True;";
+            @"Server=(localdb)\\mssqllocaldb;Database=ExtraDryIntegrationTests;Trusted_Connection=True;";
         builder.UseSqlServer(connectionString);
         return new SampleContext(builder.Options);
     }

--- a/ExtraDry/Sample.Data/Services/RegionService.cs
+++ b/ExtraDry/Sample.Data/Services/RegionService.cs
@@ -25,13 +25,14 @@ public class RegionService {
 
     public async Task CreateAsync(Region item)
     {
+        Region? parent = null;
         if(item.Level != RegionLevel.Global) {
             if(item.Parent == null) {
                 throw new ArgumentException("A region must have a parent if it is not at the global level.");
             }
-            var parent = await TryRetrieveAsync(item.Parent.Slug);
-            item.SetParent(parent);
+            parent = await TryRetrieveAsync(item.Parent.Slug);
         }
+        item.SetParent(parent);
         database.Regions.Add(item);
         await database.SaveChangesAsync();
     }

--- a/ExtraDry/Sample.Data/Services/RegionService.cs
+++ b/ExtraDry/Sample.Data/Services/RegionService.cs
@@ -51,7 +51,7 @@ public class RegionService {
     }
 
     /// <summary>
-    /// 
+    /// Updates the provided Region. If allowMove is set to true it also allows this Region to be reparented.
     /// </summary>
     /// <param name="slug">The slug that is used to identify the region to update</param>
     /// <param name="item">The item to update</param>

--- a/ExtraDry/Sample.Data/Services/RegionService.cs
+++ b/ExtraDry/Sample.Data/Services/RegionService.cs
@@ -58,6 +58,11 @@ public class RegionService {
             if(existing.Parent != null && item.Parent != null && existing.Parent.Slug != item.Parent.Slug) {
                 var newParent = await RetrieveAsync(item.Parent.Slug);
                 await existing.MoveSubtree(newParent, database);
+                database.Entry(existing).State = EntityState.Detached; // Detach the fucker.
+                existing = await RetrieveAsync(code);
+                //foreach(var loc in existing.Ancestors) {
+                //    database.Entry(loc).Reload();
+                //}
             }
             await rules.UpdateAsync(item, existing);
             await database.SaveChangesAsync();

--- a/ExtraDry/Sample.Server/Controllers/RegionController.cs
+++ b/ExtraDry/Sample.Server/Controllers/RegionController.cs
@@ -77,7 +77,7 @@ public class RegionController {
     [Authorize(SamplePolicies.SamplePolicy)]
     public async Task UpdateAsync(string code, Region item)
     {
-        await regions.UpdateAsync(code, item);
+        await regions.UpdateAsync(code, item, true);
     }
 
     /// <summary>

--- a/ExtraDry/Sample.Server/Controllers/RegionController.cs
+++ b/ExtraDry/Sample.Server/Controllers/RegionController.cs
@@ -77,7 +77,7 @@ public class RegionController {
     [Authorize(SamplePolicies.SamplePolicy)]
     public async Task UpdateAsync(string code, Region item)
     {
-        await regions.UpdateAsync(code, item, true);
+        await regions.UpdateAsync(code, item, allowMove: true);
     }
 
     /// <summary>


### PR DESCRIPTION
- Fix the functionality of adding a new item into a taxonomy (where duplicate ancestor references were being created)
- Fixed an issue with EF caching entities after running some raw SQL
- Tidied up the taxonomy extensions class. It looks like a lot, but it's just remove and sort usings, and using the new namespace notation 