### PR TITLE
Add TitleSlugAttribute and CodeSlugAttribute

### DIFF
--- a/ExtraDry/ExtraDry.Core.Tests/Annotations/CodeSlugAttributeTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Annotations/CodeSlugAttributeTests.cs
@@ -1,0 +1,32 @@
+﻿namespace ExtraDry.Core.Tests;
+
+public class CodeSlugAttributeTests {
+
+    [Theory]
+    [InlineData("acme")]
+    [InlineData("acme-co")]
+    [InlineData("Acme-Co")]
+    [InlineData("abcde-fghij-klmno")]
+    [InlineData("A1-suppliers")]
+    public void ValidCodeSlugs(string slug)
+    {
+        var titleSlug = new CodeSlugAttribute();
+        var isValid = titleSlug.IsValid(slug);
+
+        Assert.True(isValid);
+    }
+
+    [Theory]
+    [InlineData("A1_Suppliers")]
+    [InlineData("~!.=+?")]  // No other special chars allowed.
+    [InlineData("\\")]      // Backslash not allowed.
+    [InlineData("/")]       // Forward slash not allowed.
+    public void InvalidCodeSlugs(string slug)
+    {
+        var titleSlug = new CodeSlugAttribute();
+        var isValid = titleSlug.IsValid(slug);
+
+        Assert.False(isValid);
+    }
+}
+

--- a/ExtraDry/ExtraDry.Core.Tests/Annotations/TitleSlugAttributeTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Annotations/TitleSlugAttributeTests.cs
@@ -1,0 +1,35 @@
+﻿namespace ExtraDry.Core.Tests;
+
+public class TitleSlugAttributeTests {
+
+    [Theory]
+    [InlineData("acme")]
+    [InlineData("acme-co")]
+    [InlineData("abcde-fghij-klmno")]
+    [InlineData("a1-suppliers")]        // With number.
+    public void ValidTitleSlugs(string slug)
+    {
+        var titleSlug = new TitleSlugAttribute();
+        var isValid = titleSlug.IsValid(slug);
+
+        Assert.True(isValid);
+    }
+
+    [Theory]
+    [InlineData("Acme")]
+    [InlineData("Acme-Co")]
+    [InlineData("Abcde-Fghij-Klmno")]
+    [InlineData("A1-Suppliers")]
+    [InlineData("A1_Suppliers")]
+    [InlineData("~!.=+?")]  // No other special chars allowed.
+    [InlineData("\\")]      // Backslash not allowed.
+    [InlineData("/")]       // Forward slash not allowed.
+    public void InvalidTitleSlugs(string slug)
+    {
+        var titleSlug = new TitleSlugAttribute();
+        var isValid = titleSlug.IsValid(slug);
+
+        Assert.False(isValid);
+    }
+}
+

--- a/ExtraDry/ExtraDry.Core/Annotations/CodeSlugAttribute.cs
+++ b/ExtraDry/ExtraDry.Core/Annotations/CodeSlugAttribute.cs
@@ -1,0 +1,17 @@
+﻿namespace ExtraDry.Core;
+
+/// <summary>
+/// Validates that a string field is a valid Slug which is being used as a URL friendly unique ID.
+/// This only allows lowercase and uppercase letters, numbers, and hyphens.
+/// </summary>
+public class CodeSlugAttribute : RegularExpressionAttribute {
+
+    /// <inheritdoc cref="TitleSlugAttribute" />
+    public CodeSlugAttribute() : base(CodeSlugRegex)
+    {
+        ErrorMessage = "The {0} field should use only lowercase and uppercase letters, numbers and hyphens.";
+    }
+
+    private const string CodeSlugRegex = "^[a-zA-Z0-9-]+$";
+}
+

--- a/ExtraDry/ExtraDry.Core/Annotations/TitleSlugAttribute.cs
+++ b/ExtraDry/ExtraDry.Core/Annotations/TitleSlugAttribute.cs
@@ -1,0 +1,17 @@
+﻿namespace ExtraDry.Core;
+
+/// <summary>
+/// Validates that a string field is a valid Slug which is being used as a URL friendly unique ID.
+/// This only allows lowercase letters, numbers, and hyphens.
+/// </summary>
+public class TitleSlugAttribute : RegularExpressionAttribute {
+
+    /// <inheritdoc cref="TitleSlugAttribute" />
+    public TitleSlugAttribute() : base(TitleSlugRegex)
+    {
+        ErrorMessage = "The {0} field should use only lowercase letters, numbers and hyphens.";
+    }
+
+    private const string TitleSlugRegex = "^[a-z0-9-]+$";
+}
+

--- a/ExtraDry/ExtraDry.Core/WebId.cs
+++ b/ExtraDry/ExtraDry.Core/WebId.cs
@@ -27,7 +27,7 @@ public static class WebId {
     /// Given a name, with punctuation and mixed case, create a matching WebId.
     /// </summary>
     /// <remarks>
-    /// This does not guarantee uniqueness, consider `ToUniqeWebId` instead.
+    /// This does not guarantee uniqueness, consider `ToUniqueWebId` instead.
     /// </remarks>
     public static string ToWebId(string name, bool lowercase = true)
     {
@@ -61,7 +61,7 @@ public static class WebId {
     /// Given a name, with punctuation and mixed case, create a matching WebId, with a maximum length.
     /// </summary>
     /// <remarks>
-    /// This does not guarantee uniqueness, consider `ToUniqeWebId` instead.
+    /// This does not guarantee uniqueness, consider `ToUniqueWebId` instead.
     /// </remarks>
     public static string ToWebId(string name, int maxLength, bool lowercase = true)
     {


### PR DESCRIPTION
- Add TitleSlugAttribute for use when a slug can only have lowercase letters, numbers or hyphens.
- Add CodeSlugAttribute for use when a slug can only have lowercase and uppercase letters, numbers or hyphens.
- Correct some spelling mistakes.