### PR TITLE
Validate entity after properties are updated.

### DIFF
--- a/ExtraDry/ExtraDry.Server.Tests/Rules/RuleEngineUpdateCollectionAsyncTests.cs
+++ b/ExtraDry/ExtraDry.Server.Tests/Rules/RuleEngineUpdateCollectionAsyncTests.cs
@@ -58,7 +58,7 @@ public class RuleEngineUpdateCollectionAsyncTests {
         var databaseMatch = new Child { Uuid = guid, Name = "InDatabase" };
         services.ChildResolver.AddChild(databaseMatch);
         var source = new Parent { Child = new Child { Uuid = guid, Name = "IgnoreMe" } };
-        var destination = new Parent { Child = new Child { Uuid = Guid.NewGuid(), Name = "IgnoreMe" } };
+        var destination = new Parent { Child = new Child { Uuid = Guid.NewGuid(), Name = "PreviousChild" } };
 
         await rules.UpdateAsync(source, destination);
 
@@ -461,6 +461,11 @@ public class RuleEngineUpdateCollectionAsyncTests {
 
         public override int GetHashCode() => Uuid.GetHashCode();
 
+        // This is used to determine if this was created from the
+        // ResourceReferenceConverter by comparing the default property values.
+        // This can then be used to determine if validation can be run against it.
+        internal bool CreatedFromResourceReference => Name == "Child";
+
     }
 
     public class Parent : IValidatableObject {
@@ -484,7 +489,7 @@ public class RuleEngineUpdateCollectionAsyncTests {
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            if(Child?.Name == "IgnoreMe") {
+            if(Child != default && !Child.CreatedFromResourceReference && Child.Name == "PreviousChild") {
                 yield return new ValidationResult($"The {nameof(Child)} is not valid.", new[] { nameof(Child) });
             }
         }

--- a/ExtraDry/ExtraDry.Server.Tests/Rules/RuleEngineUpdateCollectionAsyncTests.cs
+++ b/ExtraDry/ExtraDry.Server.Tests/Rules/RuleEngineUpdateCollectionAsyncTests.cs
@@ -58,7 +58,7 @@ public class RuleEngineUpdateCollectionAsyncTests {
         var databaseMatch = new Child { Uuid = guid, Name = "InDatabase" };
         services.ChildResolver.AddChild(databaseMatch);
         var source = new Parent { Child = new Child { Uuid = guid, Name = "IgnoreMe" } };
-        var destination = new Parent { Child = new Child { Uuid = Guid.NewGuid() } };
+        var destination = new Parent { Child = new Child { Uuid = Guid.NewGuid(), Name = "IgnoreMe" } };
 
         await rules.UpdateAsync(source, destination);
 
@@ -463,7 +463,7 @@ public class RuleEngineUpdateCollectionAsyncTests {
 
     }
 
-    public class Parent {
+    public class Parent : IValidatableObject {
 
         [Rules(RuleAction.Block)]
         [JsonIgnore]
@@ -482,6 +482,12 @@ public class RuleEngineUpdateCollectionAsyncTests {
         [Rules(RuleAction.Block)]
         public List<Child>? BlockedChildren { get; set; }
 
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if(Child?.Name == "IgnoreMe") {
+                yield return new ValidationResult($"The {nameof(Child)} is not valid.", new[] { nameof(Child) });
+            }
+        }
     }
 
     public class ChildEntityResolver : IEntityResolver<Child> {

--- a/ExtraDry/ExtraDry.Server/RuleEngine.cs
+++ b/ExtraDry/ExtraDry.Server/RuleEngine.cs
@@ -65,12 +65,12 @@ public class RuleEngine {
     {
         ArgumentNullException.ThrowIfNull(source, nameof(source));
         ArgumentNullException.ThrowIfNull(destination, nameof(destination));
-        if(destination is IUpdatingCallback updating) {
-            await updating.OnUpdatingAsync();
-        }
         var validator = new DataValidator();
         validator.ValidateObject(source);
         validator.ThrowIfInvalid();
+        if(destination is IUpdatingCallback updating) {
+            await updating.OnUpdatingAsync();
+        }
         await UpdatePropertiesAsync(source, destination, MaxRecursionDepth, e => e.UpdateAction);
         /*
          *  Validation is run after the update on the destination to allow for 

--- a/ExtraDry/ExtraDry.Server/RuleEngine.cs
+++ b/ExtraDry/ExtraDry.Server/RuleEngine.cs
@@ -65,13 +65,17 @@ public class RuleEngine {
     {
         ArgumentNullException.ThrowIfNull(source, nameof(source));
         ArgumentNullException.ThrowIfNull(destination, nameof(destination));
-        var validator = new DataValidator();
-        validator.ValidateObject(source);
-        validator.ThrowIfInvalid();
         if(destination is IUpdatingCallback updating) {
             await updating.OnUpdatingAsync();
         }
         await UpdatePropertiesAsync(source, destination, MaxRecursionDepth, e => e.UpdateAction);
+        /*
+         *  Validation is run after the update to allow for validation that 
+         *  includes linked or resolvable entities.
+         */
+        var validator = new DataValidator();
+        validator.ValidateObject(destination);
+        validator.ThrowIfInvalid();
         if(destination is IUpdatedCallback updated) {
             await updated.OnUpdatedAsync();
         }

--- a/ExtraDry/ExtraDry.Server/RuleEngine.cs
+++ b/ExtraDry/ExtraDry.Server/RuleEngine.cs
@@ -68,12 +68,15 @@ public class RuleEngine {
         if(destination is IUpdatingCallback updating) {
             await updating.OnUpdatingAsync();
         }
+        var validator = new DataValidator();
+        validator.ValidateObject(source);
+        validator.ThrowIfInvalid();
         await UpdatePropertiesAsync(source, destination, MaxRecursionDepth, e => e.UpdateAction);
         /*
-         *  Validation is run after the update to allow for validation that 
-         *  includes linked or resolvable entities.
+         *  Validation is run after the update on the destination to allow for 
+         *  validation that includes linked or resolvable entities.
          */
-        var validator = new DataValidator();
+        validator = new DataValidator();
         validator.ValidateObject(destination);
         validator.ThrowIfInvalid();
         if(destination is IUpdatedCallback updated) {

--- a/ExtraDry/ExtraDry.Server/RuleEngine.cs
+++ b/ExtraDry/ExtraDry.Server/RuleEngine.cs
@@ -47,6 +47,15 @@ public class RuleEngine {
             await creating.OnCreatingAsync();
         }
         await UpdatePropertiesAsync(exemplar, destination, MaxRecursionDepth, e => e.CreateAction);
+        if(destination != null) {
+            /*
+             *  Validation is run after the update on the destination to allow for 
+             *  validation that includes linked or resolvable entities.
+             */
+            validator = new DataValidator();
+            validator.ValidateObject(destination);
+            validator.ThrowIfInvalid();
+        }
         if(destination is ICreatedCallback created) {
             await created.OnCreatedAsync();
         }


### PR DESCRIPTION
I've changed the validation checking in the RuleEngine `UpdateAsync` method to check the destination entity after the properties have been updated.

This was causing issues when the entity's validation included linked or resolvable entities.  I've updated a unit test with an example of the issue.