### PR TITLE
Remove args from CrudService

### DIFF
--- a/ExtraDry/ExtraDry.Blazor/Extensions/ServiceCollectionExtensions.cs
+++ b/ExtraDry/ExtraDry.Blazor/Extensions/ServiceCollectionExtensions.cs
@@ -18,10 +18,23 @@ public static class ServiceCollectionExtensions {
     /// </summary>
     public static IServiceCollection AddCrudService<T>(this IServiceCollection services, string endpointTemplate)
     {
+        services.AddCrudService<T>(options => {
+            options.CrudEndpoint = endpointTemplate;
+        });
+        return services;
+    }
+
+    public static IServiceCollection AddCrudService<T>(this IServiceCollection services, Action<CrudServiceOptions> config)
+    {
+        var options = new CrudServiceOptions();
+        config(options);
+
+        new DataValidator().ValidateObject(options);
+
         services.AddScoped(e => {
-            var client = e.GetRequiredService<HttpClient>();
+            var client = GetHttpClient(e, options);
             var logger = e.GetRequiredService<ILogger<CrudService<T>>>();
-            var service = new CrudService<T>(client, endpointTemplate, logger);
+            var service = new CrudService<T>(client, options, logger);
             return service;
         });
         return services;

--- a/ExtraDry/ExtraDry.Blazor/ExtraDry.Blazor.csproj
+++ b/ExtraDry/ExtraDry.Blazor/ExtraDry.Blazor.csproj
@@ -57,7 +57,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="BuildWebCompiler2022" Version="1.14.10" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.14" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.VsixColorCompiler" Version="17.0.31709.430" />
 		<PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />

--- a/ExtraDry/ExtraDry.Blazor/ViewModels/CrudService.cs
+++ b/ExtraDry/ExtraDry.Blazor/ViewModels/CrudService.cs
@@ -11,7 +11,7 @@ namespace ExtraDry.Blazor;
 /// The entity of Type `T must be JSON serializable and accepted by the server.
 /// On non-success (2xx) results, the service endpoints should return a ProblemDetails (RFC7807)
 /// response body.  This body will be unwrapped and throw in the body of a DryException.  If 
-/// ProblemDetails are not present, then a trivial attempt to unpacke the arbitrary response 
+/// ProblemDetails are not present, then a trivial attempt to unpack the arbitrary response 
 /// payload will be made.
 /// </summary>
 public class CrudService<T> {
@@ -32,18 +32,37 @@ public class CrudService<T> {
     /// This allows for version numbers, tenant names, etc. to be added.
     /// </param>
     /// <param name="iLogger">An optional Logger</param>
+    [Obsolete("Use Options")]
     public CrudService(HttpClient client, string collectionEndpointTemplate, ILogger<CrudService<T>>? iLogger = null)
     {
         http = client;
+        Options = new CrudServiceOptions { CrudEndpoint = collectionEndpointTemplate };
         ApiTemplate = collectionEndpointTemplate;
         logger = iLogger;
     }
 
     /// <summary>
+    /// Create a CRUD service with the specified configuration.  This service should not be 
+    /// manually added to the IServiceCollection.  Instead, use the AddCrudService`T 
+    /// extension method.
+    /// </summary>
+    public CrudService(HttpClient client, CrudServiceOptions options, ILogger<CrudService<T>> logger)
+    {
+        http = client;
+        Options = options;
+        this.logger = logger;
+        ApiTemplate = options.CrudEndpoint;
+    }
+
+    /// <summary>
     /// The API Template used to determine the final endpoint URI.
     /// </summary>
+    [Obsolete("Use from Options")]
     public string ApiTemplate { get; set; }
 
+    public CrudServiceOptions Options { get; }
+
+    [Obsolete("Inject arguments into HtttpClient derived type")]
     public async Task CreateAsync(T item, params object[] args)
     {
         var json = JsonSerializer.Serialize(item);
@@ -55,6 +74,18 @@ public class CrudService<T> {
         logger?.LogDebug("Created '{entity}' on '{endpoint}' with content: {content}", nameof(T), endpoint, json);
     }
 
+    public async Task CreateAsync(T item, CancellationToken cancellationToken = default)
+    {
+        var json = JsonSerializer.Serialize(item);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var endpoint = ApiEndpoint(nameof(CreateAsync), string.Empty);
+        logger?.LogInformation("Created '{entity}' at '{endpoint}'", nameof(T), endpoint);
+        var response = await http.PostAsync(endpoint, content, cancellationToken);
+        await response.AssertSuccess();
+        logger?.LogDebug("Created '{entity}' on '{endpoint}' with content: {content}", nameof(T), endpoint, json);
+    }
+
+    [Obsolete("Inject arguments into HtttpClient derived type")]
     public async Task<T?> RetrieveAsync(object key, params object[] args)
     {
         var endpoint = ApiEndpoint(nameof(RetrieveAsync), key, args);
@@ -66,6 +97,18 @@ public class CrudService<T> {
         return item;
     }
 
+    public async Task<T?> RetrieveAsync(object key, CancellationToken cancellationToken = default)
+    {
+        var endpoint = ApiEndpoint(nameof(RetrieveAsync), key);
+        logger?.LogInformation("Retrieving '{entity}' from '{endpoint}'", nameof(T), endpoint);
+        var response = await http.GetAsync(endpoint, cancellationToken);
+        await response.AssertSuccess();
+        var item = await response.Content.ReadFromJsonAsync<T>(cancellationToken: cancellationToken);
+        logger?.LogDebug("Retrieved '{entity}' from '{endpoint}' with content: {content}", nameof(T), endpoint, item);
+        return item;
+    }
+
+    [Obsolete("Inject arguments into HtttpClient derived type")]
     public async Task UpdateAsync(object key, T item, params object[] args)
     {
         var endpoint = ApiEndpoint(nameof(UpdateAsync), key, args);
@@ -75,6 +118,16 @@ public class CrudService<T> {
         logger?.LogDebug("Updated '{entity}' on '{endpoint}' with content: {content}", nameof(T), endpoint, item);
     }
 
+    public async Task UpdateAsync(object key, T item, CancellationToken cancellationToken = default)
+    {
+        var endpoint = ApiEndpoint(nameof(UpdateAsync), key);
+        logger?.LogInformation("Updating '{entity}' on '{endpoint}'", nameof(T), endpoint);
+        var response = await http.PutAsJsonAsync(endpoint, item, cancellationToken);
+        await response.AssertSuccess();
+        logger?.LogDebug("Updated '{entity}' on '{endpoint}' with content: {content}", nameof(T), endpoint, item);
+    }
+
+    [Obsolete("Inject arguments into HtttpClient derived type")]
     public async Task DeleteAsync(object key, params object[] args)
     {
         var endpoint = ApiEndpoint(nameof(DeleteAsync), key, args);
@@ -84,16 +137,25 @@ public class CrudService<T> {
         logger?.LogDebug("Deleted '{entity}' at '{endpoint}'", nameof(T), endpoint);
     }
 
+    public async Task DeleteAsync(object key, CancellationToken cancellationToken = default)
+    {
+        var endpoint = ApiEndpoint(nameof(DeleteAsync), key);
+        logger?.LogInformation("Deleting '{entity}' at '{endpoint}'", nameof(T), endpoint);
+        var response = await http.DeleteAsync(endpoint, cancellationToken);
+        await response.AssertSuccess();
+        logger?.LogDebug("Deleted '{entity}' at '{endpoint}'", nameof(T), endpoint);
+    }
+
     private string ApiEndpoint(string method, object key, params object[] args)
     {
         try {
-            var baseUrl = string.Format(ApiTemplate, args);
+            var baseUrl = string.Format(Options.CrudEndpoint, args);
             var url = $"{baseUrl}/{key}".TrimEnd('/');
             return url;
         }
         catch(FormatException ex) {
             var argsFormatted = string.Join(',', args?.Select(e => e?.ToString()) ?? Array.Empty<string>());
-            logger?.LogWarning("Formatting problem while constructing endpoint for `CrudService.{method}`.  Typically the endpoint provided has additional placeholders that have not been provided. The endpoint template ({ApiTemplate}), could not be satisifed with arguments ({argsFormatted}).  Inner Exception was:  {ex.Message}", method, ApiTemplate, argsFormatted, ex.Message);
+            logger?.LogWarning("Formatting problem while constructing endpoint for `CrudService.{method}`.  Typically the endpoint provided has additional placeholders that have not been provided. The endpoint template ({ApiTemplate}), could not be satisfied with arguments ({argsFormatted}).  Inner Exception was:  {ex.Message}", method, ApiTemplate, argsFormatted, ex.Message);
             throw new DryException("Error occurred connecting to server", "This is a mis-configuration and not a user error, please see the console output for more information.");
         }
     }

--- a/ExtraDry/ExtraDry.Blazor/ViewModels/CrudServiceOptions.cs
+++ b/ExtraDry/ExtraDry.Blazor/ViewModels/CrudServiceOptions.cs
@@ -1,0 +1,22 @@
+﻿namespace ExtraDry.Blazor;
+
+public class CrudServiceOptions : IHttpClientOptions, IValidatableObject {
+
+    public string HttpClientName { get; set; } = string.Empty;
+
+    public Type? HttpClientType { get; set; }
+
+    [Required]
+    public string CrudEndpoint { get; set; } = string.Empty;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if(HttpClientType != null && HttpClientName != string.Empty) {
+            yield return new ValidationResult("Only one of HttpClientType or HttpClientName can be specified.");
+        }
+
+        if(HttpClientType != null && !HttpClientType.IsSubclassOf(typeof(HttpClient))) {
+            yield return new ValidationResult("HttpClientType must define a subtype of HttpClient.");
+        }
+    }
+}

--- a/ExtraDry/ExtraDry.Swashbuckle/ExtraDry.Swashbuckle.csproj
+++ b/ExtraDry/ExtraDry.Swashbuckle/ExtraDry.Swashbuckle.csproj
@@ -25,7 +25,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.14" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 	</ItemGroup>
 

--- a/ExtraDry/Sample.Client/Sample.Client.csproj
+++ b/ExtraDry/Sample.Client/Sample.Client.csproj
@@ -29,8 +29,8 @@
 	<ItemGroup>
 		<PackageReference Include="BuildWebCompiler2022" Version="1.14.10" />
 		<PackageReference Include="BundlerMinifier.Core" Version="3.2.449" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.2" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.14" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.14" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
 		<PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
 	</ItemGroup>

--- a/ExtraDry/Sample.Server/Sample.Server.csproj
+++ b/ExtraDry/Sample.Server/Sample.Server.csproj
@@ -23,7 +23,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="EntityFrameworkCore.SqlServer.HierarchyId" Version="4.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.14" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.2" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.2">
 			<PrivateAssets>all</PrivateAssets>

--- a/ExtraDry/Sample.Shared/Sample.Shared.csproj
+++ b/ExtraDry/Sample.Shared/Sample.Shared.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="7.0.2" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="7.0.2" />
+		<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="7.0.14" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ steps:
   inputs:
     command: 'custom'
     custom: 'tool'
-    arguments: 'install --global dotnet-ef'
+    arguments: 'install --global dotnet-ef --version 7.0.14'
 
 - task: DotNetCoreCLI@2
   displayName: Restore


### PR DESCRIPTION
Updated the `CrudService` to make the methods using args parameters obsolete and switch to using options.  This follows the same approach as the `ListService` and the `StatService` pattern.