### PR TITLE
Configurable response status codes

### DIFF
--- a/ExtraDry/ExtraDry.Swashbuckle.Tests/ExtraDry.Swashbuckle.Tests.csproj
+++ b/ExtraDry/ExtraDry.Swashbuckle.Tests/ExtraDry.Swashbuckle.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ExtraDry.Swashbuckle\ExtraDry.Swashbuckle.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ExtraDry/ExtraDry.Swashbuckle.Tests/Filters/SignatureImpliesStatusCodesTests.cs
+++ b/ExtraDry/ExtraDry.Swashbuckle.Tests/Filters/SignatureImpliesStatusCodesTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.ObjectPool;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Net;
+using System.Text.Json;
+
+namespace ExtraDry.Swashbuckle.Tests.Filters
+{
+    public class SignatureImpliesStatusCodesTests
+    {
+        SchemaGenerator schemaRegistry;
+        SchemaRepository schemaRepository;
+
+        public SignatureImpliesStatusCodesTests()
+        {
+            schemaRegistry = new SchemaGenerator(new SchemaGeneratorOptions(), new JsonSerializerDataContractResolver(new JsonSerializerOptions()));
+            schemaRepository = new SchemaRepository();
+        }
+
+        [Fact]
+        public void CreateObject()
+        {
+            var filter = new SignatureImpliesStatusCodes(new ExtraDryGenOptions.HttpMethodsOptions());
+
+            Assert.NotNull(filter);
+        }
+
+        [Theory]
+        [MemberData(nameof(ChangeResponseCodeData))]
+        public void ChangeResponseCode(HttpMethod httpMethod, HttpStatusCode newHttpStatusCode, string description, string testMethod, string expectedCode, string expectedDesc)
+        {
+            var options = new ExtraDryGenOptions.HttpMethodsOptions();
+            options.AddMapping(httpMethod, newHttpStatusCode, description);
+            var filter = new SignatureImpliesStatusCodes(options);
+            var defaultResponse = new OpenApiResponse();
+            defaultResponse.Content.Add("Example", new OpenApiMediaType());
+            var operation = new OpenApiOperation();
+            operation.Responses.Add("200", defaultResponse);
+            var context = new OperationFilterContext(null, schemaRegistry, schemaRepository, typeof(DummyController).GetMethod(testMethod));
+
+            filter.Apply(operation, context);
+
+            Assert.False(operation.Responses.ContainsKey("200"));
+            Assert.True(operation.Responses.ContainsKey(expectedCode));
+            var newResponse = operation.Responses[expectedCode];
+            Assert.NotNull(newResponse.Content);
+            Assert.Equal(expectedDesc, newResponse.Description);
+        }
+
+        public static IEnumerable<object[]> ChangeResponseCodeData()
+        {
+            yield return new object[] { HttpMethod.Get,     HttpStatusCode.Accepted,        string.Empty,   nameof(DummyController.GetMethod),      "202", "Accepted" };
+            yield return new object[] { HttpMethod.Get,     HttpStatusCode.Found,           "Success",      nameof(DummyController.GetMethod),      "302", "Success" };
+            yield return new object[] { HttpMethod.Put,     HttpStatusCode.ResetContent,    string.Empty,   nameof(DummyController.PutMethod),      "205", "ResetContent" };
+            yield return new object[] { HttpMethod.Put,     HttpStatusCode.MultiStatus,     "Success",      nameof(DummyController.PutMethod),      "207", "Success" };
+            yield return new object[] { HttpMethod.Post,    HttpStatusCode.IMUsed,          string.Empty,   nameof(DummyController.PostMethod),     "226", "IMUsed" };
+            yield return new object[] { HttpMethod.Post,    HttpStatusCode.NoContent,       "Success",      nameof(DummyController.PostMethod),     "204", "Success" };
+            yield return new object[] { HttpMethod.Delete,  HttpStatusCode.Redirect,        string.Empty,   nameof(DummyController.DeleteMethod),   "302", "Success" };
+            yield return new object[] { HttpMethod.Delete,  HttpStatusCode.Accepted,        "Completed",    nameof(DummyController.DeleteMethod),   "202", "Completed" };
+        }
+    }
+
+    internal class DummyController
+    {
+        [HttpGet]
+        public void GetMethod() { }
+
+        [HttpPut]
+        public void PutMethod() { }
+
+        [HttpPost]
+        public void PostMethod() { }
+
+        [HttpDelete]
+        public void DeleteMethod() { }
+    }
+}

--- a/ExtraDry/ExtraDry.Swashbuckle.Tests/GlobalUsings.cs
+++ b/ExtraDry/ExtraDry.Swashbuckle.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/ExtraDry/ExtraDry.Swashbuckle/ExtraDryGenOptions.cs
+++ b/ExtraDry/ExtraDry.Swashbuckle/ExtraDryGenOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Net;
 
 namespace ExtraDry.Swashbuckle;
 
@@ -22,9 +21,8 @@ public class ExtraDryGenOptions
     /// </summary>
     public FilterOptions Filters { get; } = new();
 
-    public HttpMethodsOptions HttpMethodsConfig { get; } = new();
-
-    public class InstructionPageOptions {
+    public class InstructionPageOptions
+    {
 
         public bool Include { get; set; } = true;
 
@@ -40,7 +38,8 @@ public class ExtraDryGenOptions
     /// <summary>
     /// Options that control the inclusion of XML documentation.
     /// </summary>
-    public class DocumentationXmlOptions {
+    public class DocumentationXmlOptions
+    {
 
         /// <summary>
         /// Indicates if the documentation for Extra Dry classes is included (recommended).
@@ -66,7 +65,7 @@ public class ExtraDryGenOptions
         /// Endpoints that take Sort, Filter or Page Queries will have documentation added for
         /// users describing the valid properties for each endpoints query.
         /// </summary>
-        public bool EnableQueryDocumentation { get; set; } = true;  
+        public bool EnableQueryDocumentation { get; set; } = true;
 
         /// <summary>
         /// Properties in schema objects that can be inferred to be read-only are set as read-only 
@@ -88,18 +87,5 @@ public class ExtraDryGenOptions
         /// </summary>
         public bool EnableDisplayOnApiControllers { get; set; } = true;
 
-    }
-
-    public class HttpMethodsOptions
-    {
-        public void AddMapping(HttpMethod httpMethod, HttpStatusCode httpStatusCode, string description = "") => HttpMethodMapping.Add(httpMethod, new HttpStatusResponse { HttpStatusCode = httpStatusCode, Description = description });
-
-        public IDictionary<HttpMethod, HttpStatusResponse> HttpMethodMapping { get; set; } = new Dictionary<HttpMethod, HttpStatusResponse>();
-
-        public struct HttpStatusResponse
-        {
-            public HttpStatusCode HttpStatusCode { get; set; }
-            public string Description { get; set; }
-        }
     }
 }

--- a/ExtraDry/ExtraDry.Swashbuckle/ExtraDryGenOptions.cs
+++ b/ExtraDry/ExtraDry.Swashbuckle/ExtraDryGenOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Net;
 
 namespace ExtraDry.Swashbuckle;
 
@@ -20,6 +21,8 @@ public class ExtraDryGenOptions
     /// Options for turning on/off specific filters that augment the OpenAPI document.
     /// </summary>
     public FilterOptions Filters { get; } = new();
+
+    public HttpMethodsOptions HttpMethodsConfig { get; } = new();
 
     public class InstructionPageOptions {
 
@@ -86,5 +89,17 @@ public class ExtraDryGenOptions
         public bool EnableDisplayOnApiControllers { get; set; } = true;
 
     }
-}
 
+    public class HttpMethodsOptions
+    {
+        public void AddMapping(HttpMethod httpMethod, HttpStatusCode httpStatusCode, string description = "") => HttpMethodMapping.Add(httpMethod, new HttpStatusResponse { HttpStatusCode = httpStatusCode, Description = description });
+
+        public IDictionary<HttpMethod, HttpStatusResponse> HttpMethodMapping { get; set; } = new Dictionary<HttpMethod, HttpStatusResponse>();
+
+        public struct HttpStatusResponse
+        {
+            public HttpStatusCode HttpStatusCode { get; set; }
+            public string Description { get; set; }
+        }
+    }
+}

--- a/ExtraDry/ExtraDry.Swashbuckle/SwaggerOptionsExtensions.cs
+++ b/ExtraDry/ExtraDry.Swashbuckle/SwaggerOptionsExtensions.cs
@@ -35,7 +35,7 @@ public static class SwaggerOptionsExtensions {
         }
 
         if(options.Filters.EnableSignatureStatusCodes) {
-            openapi.OperationFilter<SignatureImpliesStatusCodes>();
+            openapi.OperationFilter<SignatureImpliesStatusCodes>(options.HttpMethodsConfig);
         }
         if(options.Filters.EnableQueryDocumentation) {
             openapi.OperationFilter<QueryDocumentationOperationFilter>();

--- a/ExtraDry/ExtraDry.Swashbuckle/SwaggerOptionsExtensions.cs
+++ b/ExtraDry/ExtraDry.Swashbuckle/SwaggerOptionsExtensions.cs
@@ -35,7 +35,7 @@ public static class SwaggerOptionsExtensions {
         }
 
         if(options.Filters.EnableSignatureStatusCodes) {
-            openapi.OperationFilter<SignatureImpliesStatusCodes>(options.HttpMethodsConfig);
+            openapi.OperationFilter<SignatureImpliesStatusCodes>();
         }
         if(options.Filters.EnableQueryDocumentation) {
             openapi.OperationFilter<QueryDocumentationOperationFilter>();

--- a/ExtraDry/ExtraDry.sln
+++ b/ExtraDry/ExtraDry.sln
@@ -53,7 +53,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.WebJobs", "Sample.We
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample.Tests", "Sample.Tests\Sample.Tests.csproj", "{75C4867C-65AF-40F0-83A2-54CD91377279}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExtraDry.Blazor.Experimental", "ExtraDry.Blazor.Experimental\ExtraDry.Blazor.Experimental.csproj", "{7B9FEC78-072D-4D09-8E26-7A4B07B6FFCF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtraDry.Blazor.Experimental", "ExtraDry.Blazor.Experimental\ExtraDry.Blazor.Experimental.csproj", "{7B9FEC78-072D-4D09-8E26-7A4B07B6FFCF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExtraDry.Swashbuckle.Tests", "ExtraDry.Swashbuckle.Tests\ExtraDry.Swashbuckle.Tests.csproj", "{C271B8E0-17FB-477C-AA87-D8BCCD9226C6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -117,6 +119,10 @@ Global
 		{7B9FEC78-072D-4D09-8E26-7A4B07B6FFCF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7B9FEC78-072D-4D09-8E26-7A4B07B6FFCF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7B9FEC78-072D-4D09-8E26-7A4B07B6FFCF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C271B8E0-17FB-477C-AA87-D8BCCD9226C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C271B8E0-17FB-477C-AA87-D8BCCD9226C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C271B8E0-17FB-477C-AA87-D8BCCD9226C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C271B8E0-17FB-477C-AA87-D8BCCD9226C6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ExtraDry/code-cover.ps1
+++ b/ExtraDry/code-cover.ps1
@@ -2,6 +2,7 @@ rmdir ./TestCoverage -Recurse
 rmdir ./ExtraDry.Blazor.Tests/TestResults -Recurse
 rmdir ./ExtraDry.Core.Tests/TestResults -Recurse
 rmdir ./ExtraDry.Server.Tests/TestResults -Recurse
+rmdir ./ExtraDry.Swashbuckle.Tests/TestResults -Recurse
 rmdir ./Sample.Tests/TestResults -Recurse
 
 dotnet test --collect:"XPlat Code Coverage"
@@ -11,4 +12,5 @@ reportgenerator -reports:./*/TestResults/*/*.xml -targetdir:./TestCoverage
 rmdir ./ExtraDry.Blazor.Tests/TestResults -Recurse
 rmdir ./ExtraDry.Core.Tests/TestResults -Recurse
 rmdir ./ExtraDry.Server.Tests/TestResults -Recurse
+rmdir ./ExtraDry.Swashbuckle.Tests/TestResults -Recurse
 rmdir ./Sample.Tests/TestResults -Recurse


### PR DESCRIPTION
Provides the ability for the consumer to override the response status codes and description displayed in the generated Open API documentation.

Below show an example of the configuration, the `AddMapping` method also has an option description parameter.  This would override the default status code of the `POST` method with "201".  As no description is provided the enum name is used i.e. "Created".
```C
services.AddSwaggerGen(openapi => {
    openapi.AddExtraDry(options => {
        options.HttpMethodsConfig.AddMapping(HttpMethod.Post, HttpStatusCode.Created);
    });
});
```
This would result in the following being generated:
![image](https://github.com/fmi-works/extra-dry/assets/4111289/dcee74cb-01cc-4b2f-8fa1-5df9389b38ec)
