### PR TITLE
Return configurable problem details for unauthorised response.

### DIFF
--- a/ExtraDry/ExtraDry.Server/AuthorizationResponse.cs
+++ b/ExtraDry/ExtraDry.Server/AuthorizationResponse.cs
@@ -19,8 +19,13 @@ public class AuthorizationResponse {
     {
         await next(context);
 
-        if(context.Response.StatusCode == (int)HttpStatusCode.Forbidden) {
-            ProblemDetailsResponse.RewriteResponse(context, HttpStatusCode.Forbidden, options.ForbiddenTitle, options.ForbiddenMessage);
+        switch(context.Response.StatusCode) {
+            case (int)HttpStatusCode.Forbidden:
+                ProblemDetailsResponse.RewriteResponse(context, HttpStatusCode.Forbidden, options.ForbiddenTitle, options.ForbiddenMessage);
+                break;
+            case (int)HttpStatusCode.Unauthorized:
+                ProblemDetailsResponse.RewriteResponse(context, HttpStatusCode.Unauthorized, options.UnauthorizedTitle, options.UnauthorizedMessage);
+                break;
         }
     }
 }

--- a/ExtraDry/ExtraDry.Server/ExtraDryOptions.cs
+++ b/ExtraDry/ExtraDry.Server/ExtraDryOptions.cs
@@ -5,4 +5,8 @@ public class ExtraDryOptions {
     public string? ForbiddenTitle { get; set; }
 
     public string? ForbiddenMessage { get; set; }
+
+    public string? UnauthorizedTitle { get; set; }
+
+    public string? UnauthorizedMessage { get; set; }
 }


### PR DESCRIPTION
Update to return a `ProblemDetails` when an unauthorised request is made.  As with the `Forbidden` response a configurable `Title` and `Message` is provided to allow the consumer to override the default values.

```c
services.AddExtraDry(options => {
    options.UnauthorizedTitle = "You do not have the necessary authorisation to access this resource.";
    options.UnauthorizedMessage = "The resource you're trying to access is restricted. Please ensure you're logged in with the appropriate credentials.";
});
```
![image](https://github.com/fmi-works/extra-dry/assets/4111289/e889a8e9-cf76-460d-8396-4eecc529f74c)
