### PR TITLE
Rework vulnerable packages.

### DIFF
--- a/ExtraDry/ExtraDry.Core.Tests/ExtraDry.Core.Tests.csproj
+++ b/ExtraDry/ExtraDry.Core.Tests/ExtraDry.Core.Tests.csproj
@@ -16,7 +16,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.14" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.15" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/ExtraDry/ExtraDry.Server.Tests/ExtraDry.Server.Tests.csproj
+++ b/ExtraDry/ExtraDry.Server.Tests/ExtraDry.Server.Tests.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.14" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.14" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.15" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.15" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/ExtraDry/ExtraDry.Server/ExtraDry.Server.csproj
+++ b/ExtraDry/ExtraDry.Server/ExtraDry.Server.csproj
@@ -38,9 +38,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.12.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.14" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.14" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.14">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.15" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.15" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.15">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/ExtraDry/Sample.Data/Sample.Data.csproj
+++ b/ExtraDry/Sample.Data/Sample.Data.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.14" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.14">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.15" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.15">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/ExtraDry/Sample.Server/Sample.Server.csproj
+++ b/ExtraDry/Sample.Server/Sample.Server.csproj
@@ -15,8 +15,8 @@
 	<ItemGroup>
 		<PackageReference Include="CsvHelper" Version="30.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.14" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.14" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.14">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.15" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.15">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/ExtraDry/Sample.Tests/Sample.Tests.csproj
+++ b/ExtraDry/Sample.Tests/Sample.Tests.csproj
@@ -11,7 +11,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.14" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.15" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="xunit" Version="2.4.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/ExtraDry/VulnerabilityFixes.targets
+++ b/ExtraDry/VulnerabilityFixes.targets
@@ -21,7 +21,9 @@
 
 		<!-- vulnerability https://github.com/advisories/GHSA-8g2p-5pqh-5jmc -->
 		<PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+	</ItemGroup>
 
+	<ItemGroup Condition="'$(AssemblyName)' == 'ExtraDry.Core'">
 		<!-- vulnerability https://github.com/advisories/GHSA-8g9c-28fc-mcx2 &
 			 https://github.com/advisories/GHSA-59j7-ghrg-fj52
 			 
@@ -29,8 +31,8 @@
 			 and waiting to be replaced by Microsoft.EntityFrameworkCore.SqlServer.HierarchyId once we move to
 			 net8.0.  Once this is done these references can be removed.
 		-->
-		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.1.2" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
-
+		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.35.0" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
 	</ItemGroup>
+	
 </Project>


### PR DESCRIPTION
The last update to the packages resolved the vulnerability but created a runtime error.

This rework has looked at each of the packages that referenced either `Microsoft.IdentityModel.JsonWebTokens` or `System.IdentityModel.Tokens.Jwt` and updated their version.

This just left `ExtraDry.Core` with the issue, which is forced to use a safe package version via `VulnerabilityFixes.targets`.