### PR TITLE
Update file database to add new mime type for cvs files.

### DIFF
--- a/ExtraDry/ExtraDry.Server/Blobs/FileDatabase.json
+++ b/ExtraDry/ExtraDry.Server/Blobs/FileDatabase.json
@@ -1218,7 +1218,7 @@
   {
     "Description": "Comma Seperated Values",
     "Extensions": [ "csv" ],
-    "MimeTypes": [ "text/csv" ],
+    "MimeTypes": [ "text/csv", "application/vnd.ms-excel" ],
     "MagicBytes": []
   },
   {


### PR DESCRIPTION
Firefox uses "application/vnd.ms-excel" as the content type for CSV files, adding this to the `FileDatabase.json` as a valid mime type.