### PR TITLE
Fix a couple of issues around the continuation token.

### DIFF
--- a/ExtraDry/ExtraDry.Core/FilterSortPage/Queries/PageQuery.cs
+++ b/ExtraDry/ExtraDry.Core/FilterSortPage/Queries/PageQuery.cs
@@ -10,11 +10,7 @@ public class PageQuery : SortQuery, IPageQuery
     public int Skip { get; set; }
 
     /// <inheritdoc cref="IPageQuery.Take" />
-    public int Take {
-        get => take <= 0 ? DefaultTake : take;
-        set => take = value;
-    }
-    private int take;
+    public int Take { get; set;}
 
     /// <inheritdoc cref="IPageQuery.Token" />
     public string? Token { get; set; }

--- a/ExtraDry/ExtraDry.Server.Tests/Queries/PagedListQueryableTests.cs
+++ b/ExtraDry/ExtraDry.Server.Tests/Queries/PagedListQueryableTests.cs
@@ -38,6 +38,33 @@ public class PagedListQueryableTests {
         Assert.NotNull(actual.ContinuationToken);
         var token = ContinuationToken.FromString(actual.ContinuationToken);
         Assert.NotNull(token);
+        Assert.Equal(skip + take, token.Skip);
+        Assert.Equal(take, token.Take);
+    }
+
+    [Theory]
+    [InlineData(0, 5)]
+    [InlineData(5, 5)]
+    public void NextResultsUsingOnlyToken(int skip, int take)
+    {
+        var query = new PageQuery { Token = new ContinuationToken(null, null, skip, take).ToString() };
+        var expected = Models.ToList().Skip(skip).Take(take);
+
+        var actual = Models.AsQueryable().QueryWith(query).ToPagedCollection();
+
+        Assert.Equal(expected.Count(), actual.Count);
+        Assert.Equal(expected, actual.Items);
+        Assert.Equal(Models.Count, actual.Total);
+        Assert.Equal(take, actual.Count);
+        Assert.Equal(skip, actual.Start);
+        Assert.Null(actual.Filter);
+        Assert.Null(actual.Sort);
+        Assert.False(actual.IsFullCollection);
+        Assert.NotNull(actual.ContinuationToken);
+        var token = ContinuationToken.FromString(actual.ContinuationToken);
+        Assert.NotNull(token);
+        Assert.Equal(skip + take, token.Skip);
+        Assert.Equal(take, token.Take);
     }
 
     [Theory]
@@ -46,7 +73,7 @@ public class PagedListQueryableTests {
     public async Task BasicSkipTakePagingAsync(int skip, int take)
     {
         var query = new PageQuery { Skip = skip, Take = take };
-        var expected = Models.ToList().Skip(skip).Take(5);
+        var expected = Models.ToList().Skip(skip).Take(take);
 
         var actual = await Models.AsQueryable().QueryWith(query).ToPagedCollectionAsync();
 
@@ -60,6 +87,143 @@ public class PagedListQueryableTests {
         Assert.NotNull(actual.ContinuationToken);
         var token = ContinuationToken.FromString(actual.ContinuationToken);
         Assert.NotNull(token);
+        Assert.Equal(skip + take, token.Skip);
+        Assert.Equal(take, token.Take);
+    }
+
+    [Fact]
+    public async Task SkipTakeLastPageAsync()
+    {
+        var query = new PageQuery { Skip = 0, Take = 15 };
+        var expected = Models.ToList().Skip(0).Take(15);
+
+        var actual = await Models.AsQueryable().QueryWith(query).ToPagedCollectionAsync();
+
+        Assert.Equal(expected, actual.Items);
+        Assert.Equal(Models.Count, actual.Total);
+        Assert.Equal(13, actual.Count);
+        Assert.Equal(0, actual.Start);
+        Assert.Null(actual.Filter);
+        Assert.Null(actual.Sort);
+        Assert.True(actual.IsFullCollection);
+        Assert.NotNull(actual.ContinuationToken);
+        var token = ContinuationToken.FromString(actual.ContinuationToken);
+        Assert.NotNull(token);
+        Assert.Equal(0, token.Skip);
+        Assert.Equal(15, token.Take);
+    }
+
+    [Fact]
+    public async Task SkipTakePastLastPageAsync()
+    {
+        var query = new PageQuery { Skip = 15, Take = 5 };
+        var expected = Models.ToList().Skip(15).Take(5);
+
+        var actual = await Models.AsQueryable().QueryWith(query).ToPagedCollectionAsync();
+
+        Assert.Equal(expected, actual.Items);
+        Assert.Equal(Models.Count, actual.Total);
+        Assert.Equal(0, actual.Count);
+        Assert.Equal(15, actual.Start);
+        Assert.Null(actual.Filter);
+        Assert.Null(actual.Sort);
+        Assert.False(actual.IsFullCollection);
+        Assert.NotNull(actual.ContinuationToken);
+        var token = ContinuationToken.FromString(actual.ContinuationToken);
+        Assert.NotNull(token);
+        Assert.Equal(15, token.Skip);
+        Assert.Equal(5, token.Take);
+    }
+
+    [Theory]
+    [InlineData(0, 5)]
+    [InlineData(5, 5)]
+    public async Task NextResultsUsingOnlyTokenAsync(int skip, int take)
+    {
+        var query = new PageQuery { Token = new ContinuationToken(null, null, skip, take).ToString() };
+        var expected = Models.ToList().Skip(skip).Take(take);
+
+        var actual = await Models.AsQueryable().QueryWith(query).ToPagedCollectionAsync();
+
+        Assert.Equal(expected, actual.Items);
+        Assert.Equal(Models.Count, actual.Total);
+        Assert.Equal(take, actual.Count);
+        Assert.Equal(skip, actual.Start);
+        Assert.Null(actual.Filter);
+        Assert.Null(actual.Sort);
+        Assert.False(actual.IsFullCollection);
+        Assert.NotNull(actual.ContinuationToken);
+        var token = ContinuationToken.FromString(actual.ContinuationToken);
+        Assert.NotNull(token);
+        Assert.Equal(skip + take, token.Skip);
+        Assert.Equal(take, token.Take);
+    }
+
+    [Fact]
+    public async Task NextResultsUsingOnlyTokenLastPageAsync()
+    {
+        var query = new PageQuery { Token = new ContinuationToken(null, null, 10, 5).ToString() };
+        var expected = Models.ToList().Skip(10).Take(5);
+
+        var actual = await Models.AsQueryable().QueryWith(query).ToPagedCollectionAsync();
+
+        Assert.Equal(expected, actual.Items);
+        Assert.Equal(Models.Count, actual.Total);
+        Assert.Equal(3, actual.Count);
+        Assert.Equal(10, actual.Start);
+        Assert.Null(actual.Filter);
+        Assert.Null(actual.Sort);
+        Assert.False(actual.IsFullCollection);
+        var token = ContinuationToken.FromString(actual.ContinuationToken);
+        Assert.NotNull(token);
+        Assert.Equal(10, token.Skip);
+        Assert.Equal(5, token.Take);
+    }
+
+    [Fact]
+    public async Task NextResultsUsingOnlyTokenPastLastPageAsync()
+    {
+        var query = new PageQuery { Token = new ContinuationToken(null, null, 15, 5).ToString() };
+        var expected = Models.ToList().Skip(15).Take(5);
+
+        var actual = await Models.AsQueryable().QueryWith(query).ToPagedCollectionAsync();
+
+        Assert.Equal(expected, actual.Items);
+        Assert.Equal(Models.Count, actual.Total);
+        Assert.Equal(0, actual.Count);
+        Assert.Equal(15, actual.Start);
+        Assert.Null(actual.Filter);
+        Assert.Null(actual.Sort);
+        Assert.False(actual.IsFullCollection);
+        var token = ContinuationToken.FromString(actual.ContinuationToken);
+        Assert.NotNull(token);
+        Assert.Equal(15, token.Skip);
+        Assert.Equal(5, token.Take);
+    }
+
+    [Theory]
+    [InlineData(2, null, 0, 5)]
+    [InlineData(null, 2, 5, 5)]
+    [InlineData(2, 2, 5, 5)]
+    public async Task NextResultsUsingTokenAndQueryOverrideAsync(int? querySkip, int? queryTake, int tokenSkip, int tokenTake)
+    {
+        var query = new PageQuery { Skip = querySkip ?? 0, Take = queryTake ?? 0, Token = new ContinuationToken(null, null, tokenSkip, tokenTake).ToString() };
+        var expected = Models.ToList().Skip(querySkip ?? tokenSkip).Take(queryTake ?? tokenTake);
+
+        var actual = await Models.AsQueryable().QueryWith(query).ToPagedCollectionAsync();
+
+        Assert.Equal(expected, actual.Items);
+        Assert.Equal(Models.Count, actual.Total);
+        Assert.Equal(queryTake ?? tokenTake, actual.Count);
+        Assert.Equal(querySkip ?? tokenSkip, actual.Start);
+        Assert.Null(actual.Filter);
+        Assert.Null(actual.Sort);
+        Assert.False(actual.IsFullCollection);
+        Assert.NotNull(actual.ContinuationToken);
+        var token = ContinuationToken.FromString(actual.ContinuationToken);
+        Assert.NotNull(token);
+        Assert.Equal((querySkip ?? tokenSkip) + (queryTake ?? tokenTake), token.Skip);
+        Assert.Equal(queryTake ?? tokenTake, token.Take);
     }
 
     [Fact]

--- a/ExtraDry/ExtraDry.Server.Tests/Rules/SupportClasses/ContinuationTokenTests.cs
+++ b/ExtraDry/ExtraDry.Server.Tests/Rules/SupportClasses/ContinuationTokenTests.cs
@@ -161,4 +161,22 @@ public class ContinuationTokenTests {
         Assert.Equal(expectedTake, next.Take);
     }
 
+    [Fact]
+    public void IncrementingNextToken()
+    {
+        var skip = 0;
+        var take = 10;
+
+        var tokenOne = new ContinuationToken("filter", "sort", skip, take);
+        var tokenTwo = tokenOne.Next(0, 0);
+        var tokenThree = tokenTwo.Next(0, 0);
+
+        Assert.Equal(0, tokenOne.Skip);
+        Assert.Equal(10, tokenOne.Take);
+        Assert.Equal(10, tokenTwo.Skip);
+        Assert.Equal(10, tokenTwo.Take);
+        Assert.Equal(20, tokenThree.Skip);
+        Assert.Equal(10, tokenThree.Take);
+    }
+
 }

--- a/ExtraDry/ExtraDry.Server/Models/PagedListQueryable.cs
+++ b/ExtraDry/ExtraDry.Server/Models/PagedListQueryable.cs
@@ -15,7 +15,6 @@ public class PagedListQueryable<T> : SortedListQueryable<T>
         PagedQuery = SortedQuery.Page(pageQuery);
     }
 
-
     /// <inheritdoc cref="IFilteredQueryable{T}.ToPagedCollection"/>
     public PagedCollection<T> ToPagedCollection() =>
         CreatePagedCollection(PagedQuery.ToList());
@@ -31,18 +30,18 @@ public class PagedListQueryable<T> : SortedListQueryable<T>
         var take = query.Take;
         var sort = query.Sort;
 
-        var nextToken = (Token ?? new ContinuationToken(Query.Filter, sort, take, take)).Next(skip, take);
+        var lastToken = Token ?? new ContinuationToken(Query.Filter, sort, skip, take);
+        var nextToken = lastToken.Next(skip, take);
         var previousTake = ContinuationToken.ActualTake(Token, take);
         var previousSkip = ContinuationToken.ActualSkip(Token, skip);
-        var total = items.Count == previousTake ? FilteredQuery.Count() : previousSkip + items.Count;
+
         return new PagedCollection<T> {
             Items = items,
             Filter = nextToken.Filter,
             Sort = nextToken.Sort,
             Start = previousSkip,
-            Total = total,
-            ContinuationToken = nextToken.ToString(),
+            Total = FilteredQuery.Count(),
+            ContinuationToken = (previousSkip + items.Count) >= FilteredQuery.Count() ? lastToken.ToString() : nextToken.ToString(),
         };
     }
-
 }


### PR DESCRIPTION
Fixed an issue with the continuation token skipping the second page and the tokens take value not being overridden default take value.

Added some more unit tests which highlighted an issue with the total and token when paging past the items available.  These have also been resolved.