### PR TITLE
Continuation token for the last page will skip to last record returned.

### DIFF
--- a/ExtraDry/ExtraDry.Server.Tests/Queries/PagedListQueryableTests.cs
+++ b/ExtraDry/ExtraDry.Server.Tests/Queries/PagedListQueryableTests.cs
@@ -109,7 +109,7 @@ public class PagedListQueryableTests {
         Assert.NotNull(actual.ContinuationToken);
         var token = ContinuationToken.FromString(actual.ContinuationToken);
         Assert.NotNull(token);
-        Assert.Equal(0, token.Skip);
+        Assert.Equal(13, token.Skip);
         Assert.Equal(15, token.Take);
     }
 
@@ -131,7 +131,7 @@ public class PagedListQueryableTests {
         Assert.NotNull(actual.ContinuationToken);
         var token = ContinuationToken.FromString(actual.ContinuationToken);
         Assert.NotNull(token);
-        Assert.Equal(15, token.Skip);
+        Assert.Equal(13, token.Skip);
         Assert.Equal(5, token.Take);
     }
 
@@ -176,7 +176,7 @@ public class PagedListQueryableTests {
         Assert.False(actual.IsFullCollection);
         var token = ContinuationToken.FromString(actual.ContinuationToken);
         Assert.NotNull(token);
-        Assert.Equal(10, token.Skip);
+        Assert.Equal(13, token.Skip);
         Assert.Equal(5, token.Take);
     }
 
@@ -197,7 +197,7 @@ public class PagedListQueryableTests {
         Assert.False(actual.IsFullCollection);
         var token = ContinuationToken.FromString(actual.ContinuationToken);
         Assert.NotNull(token);
-        Assert.Equal(15, token.Skip);
+        Assert.Equal(13, token.Skip);
         Assert.Equal(5, token.Take);
     }
 


### PR DESCRIPTION
When retrieving the last page, or beyond the last page, the continuation token returned will last record returned.

As an example; the query results in 13 items, with a skip value of 10 and a take value of 5, this would result in 3 items being returned.  Therefore the continuation tokens skip and take values will be 13 and 5.