### PR TITLE
Only register DryTable Events once.

### DIFF
--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor.cs
@@ -74,16 +74,20 @@ public partial class DryTable<TItem> : ComponentBase, IDisposable, IExtraDryComp
     protected override void OnParametersSet()
     {
         AssertItemsMutualExclusivity();
-        resolvedSelection = Selection ?? SelectionSet.Lookup(ViewModel) ?? SelectionSet.Register(ViewModel);
-        resolvedSelection.MultipleSelect = description.ListSelectMode == ListSelectMode.Multiple;
-        resolvedSelection.Changed += ResolvedSelection_Changed;
-        if(QueryBuilder != null) {
+        if(resolvedSelection == null) {
+            resolvedSelection = Selection ?? SelectionSet.Lookup(ViewModel) ?? SelectionSet.Register(ViewModel);
+            resolvedSelection.MultipleSelect = description.ListSelectMode == ListSelectMode.Multiple;
+            resolvedSelection.Changed += ResolvedSelection_Changed;
+        }
+        if(QueryBuilder != null && !queryBuilderEventSet) {
             QueryBuilder.OnChanged += Notify_OnChanged;
+            queryBuilderEventSet = true;
         }
     }
 
     private void ResolvedSelection_Changed(object? sender, SelectionSetChangedEventArgs e)
     {
+        Logger.LogConsoleVerbose("Got selection notification");
         // Checking/unchecking a row could affect the column checkbox...
         StateHasChanged();
     }
@@ -92,7 +96,7 @@ public partial class DryTable<TItem> : ComponentBase, IDisposable, IExtraDryComp
 
     private async void Notify_OnChanged(object? sender, EventArgs e)
     {
-        Console.WriteLine("Got notification");
+        Logger.LogConsoleVerbose("Got notification");
         changing = true;
         StateHasChanged();
         InternalItems.Clear();
@@ -312,11 +316,15 @@ public partial class DryTable<TItem> : ComponentBase, IDisposable, IExtraDryComp
     public void Dispose()
     {
         GC.SuppressFinalize(this);
-        if(resolvedSelection != null) {
+        if(resolvedSelection != null && resolvedSelectionEventSet) {
             resolvedSelection.Changed -= ResolvedSelection_Changed;
+        }
+        if(QueryBuilder != null && queryBuilderEventSet) {
+            QueryBuilder.OnChanged -= Notify_OnChanged;
         }
     }
 
     private readonly SemaphoreSlim serviceLock = new(1, 1);
-
+    private bool resolvedSelectionEventSet = false;
+    private bool queryBuilderEventSet = false;
 }

--- a/ExtraDry/ExtraDry.Blazor/Internal/Builders/QueryBuilder.cs
+++ b/ExtraDry/ExtraDry.Blazor/Internal/Builders/QueryBuilder.cs
@@ -14,13 +14,13 @@ public class QueryBuilder {
     }
 
     /// <summary>
-    /// Event to subscribe to to be notified when the page query has changed and views should 
+    /// Event to subscribe to be notified when the page query has changed and views should 
     /// be refreshed.
     /// </summary>
     public event EventHandler? OnChanged;
 
     /// <summary>
-    /// Manually rebuilds the query and notifices all observers that changes have been made.
+    /// Manually rebuilds the query and notifies all observers that changes have been made.
     /// </summary>
     public void NotifyChanged()
     {


### PR DESCRIPTION
The `Notify_OnChanged` and `ResolvedSelection_Changed` events were being registered each time the `OnParametersSet` event occured, leading to the events being triggered multiple times.  This ensures that the events are only registered once. 