### PR TITLE
Remove sorting ability on hierarchy lists and scrolling issue

### DIFF
--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor.cs
@@ -184,7 +184,12 @@ public partial class DryTable<TItem> : ComponentBase, IDisposable, IExtraDryComp
         }
     }
 
-    private bool IsHierarchyList => (InternalItems.FirstOrDefault() as IHierarchyEntity) is not null;
+    private bool IsHierarchyList { 
+        get {
+            var firstEntity = InternalItems.FirstOrDefault(e => e.Item != null);
+            return firstEntity != null && firstEntity.Item is IHierarchyEntity;
+        } 
+    }
 
     private void SortBy(PropertyDescription property, bool reverseOrder = true)
     {

--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor.cs
@@ -184,18 +184,7 @@ public partial class DryTable<TItem> : ComponentBase, IDisposable, IExtraDryComp
         }
     }
 
-    private bool IsHierarchyList { 
-        get {
-            var listItem = InternalItems.FirstOrDefault(e => e.Item != null);
-            if(listItem == null) {
-                return false;
-            }
-            if(listItem.Item is IHierarchyEntity) {
-                return true;
-            }
-            return false;
-        } 
-    }
+    private bool IsHierarchyList => (InternalItems.FirstOrDefault() as IHierarchyEntity) is not null;
 
     private void SortBy(PropertyDescription property, bool reverseOrder = true)
     {

--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor.cs
@@ -186,8 +186,7 @@ public partial class DryTable<TItem> : ComponentBase, IDisposable, IExtraDryComp
 
     private bool IsHierarchyList { 
         get {
-            var firstEntity = InternalItems.FirstOrDefault(e => e.Item != null);
-            return firstEntity != null && firstEntity.Item is IHierarchyEntity;
+            return InternalItems.Any(e => e.Item is IHierarchyEntity);
         } 
     }
 

--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor.cs
@@ -184,8 +184,25 @@ public partial class DryTable<TItem> : ComponentBase, IDisposable, IExtraDryComp
         }
     }
 
+    private bool IsHierarchyList { 
+        get {
+            var listItem = InternalItems.FirstOrDefault(e => e.Item != null);
+            if(listItem == null) {
+                return false;
+            }
+            if(listItem.Item is IHierarchyEntity) {
+                return true;
+            }
+            return false;
+        } 
+    }
+
     private void SortBy(PropertyDescription property, bool reverseOrder = true)
     {
+        if(IsHierarchyList) {
+            return;
+        }
+
         var sort = property.Property.Name;
         if(sort == QueryBuilder.Sort.SortProperty) {
             if(reverseOrder) {
@@ -246,11 +263,6 @@ public partial class DryTable<TItem> : ComponentBase, IDisposable, IExtraDryComp
             }
             if(AllItemsCached(request.StartIndex, request.Count)) {
                 Logger.LogConsoleVerbose("Returning cached results");
-                var count = Math.Min(request.Count, InternalItems.Count);
-                var items = InternalItems.GetRange(request.StartIndex, count);
-                PerformInitialSort();
-
-                return new ItemsProviderResult<ListItemInfo<TItem>>(items, InternalItems.Count);
             }
             else {
                 Logger.LogConsoleVerbose("Loading page of items from remote service.");
@@ -282,7 +294,9 @@ public partial class DryTable<TItem> : ComponentBase, IDisposable, IExtraDryComp
             if(InternalItems.Any()) {
                 var count = Math.Min(request.Count, InternalItems.Count);
                 var items = InternalItems.GetRange(request.StartIndex, count);
-                PerformInitialSort();
+                if(!IsHierarchyList) {
+                    PerformInitialSort();
+                }
                 return new ItemsProviderResult<ListItemInfo<TItem>>(items, InternalItems.Count);
             }
             else {


### PR DESCRIPTION
Added a new private property for a list to change functionality if its contents are Hierarchy items. The property checks the contents of the list to make this determination.

If this is a hierarchy list, we prevent the clicking of table headers to trigger a sort (the API will not allow sorting on anything other than hierarchy ID, so we're making the UI match) and prevents the sort classes from applying to the table header.

Also removed some duplicated code on the GetItemsAsync(), and then prevented an additional sort on new paged data if the information is hierarchical. 