### PR TITLE
Parsing date filter

### DIFF
--- a/ExtraDry/ExtraDry.Server.Tests/Internals/LinqBuilderTests.cs
+++ b/ExtraDry/ExtraDry.Server.Tests/Internals/LinqBuilderTests.cs
@@ -3,7 +3,8 @@ using System.Reflection;
 
 namespace ExtraDry.Server.Tests.Internals;
 
-public class LinqBuilderTests {
+public class LinqBuilderTests
+{
 
     [Fact]
     public void OrderByNameCompatible()
@@ -128,6 +129,217 @@ public class LinqBuilderTests {
         Assert.Equal(linqWhere, linqBuilderWhere);
     }
 
+    [Theory]
+    [MemberData(nameof(FilteredDatesData))]
+    public void FilteredDates(List<Datum> sampleData, string filterProperty, string filterValue, Func<Datum, bool> expectedResults)
+    {
+        var linqWhere = sampleData.Where(expectedResults).ToList();
+
+        var property = GetFilterProperty(filterProperty);
+        var linqBuilderWhere = sampleData.AsQueryable().WhereFilterConditions(new FilterProperty[] { property }, $"{filterProperty}:{filterValue}").ToList();
+
+        Assert.Equal(linqWhere, linqBuilderWhere);
+    }
+
+    public static IEnumerable<object[]> FilteredDatesData =>
+        new List<object[]>
+        {
+            // 1. Test inclusive start year
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2023, 1, 1) },
+                    new Datum { Created = new DateTime(2022, 12, 31) },
+                    new Datum { Created = new DateTime(2024, 5, 23) },
+                }, "Created", "[2023,]", new Func<Datum, bool>(e => e.Created >= new DateTime(2023, 1, 1)),
+            },
+            // 2. Test exclusive start year
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2024, 1, 1) },
+                    new Datum { Created = new DateTime(2023, 12, 31) },
+                    new Datum { Created = new DateTime(2024, 5, 23) },
+                }, "Created", "(2023,]", new Func<Datum, bool>(e => e.Created >= new DateTime(2024, 1, 1)),
+            },
+            // 3. Test inclusive end year
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2023, 12, 31) },
+                    new Datum { Created = new DateTime(2024, 1, 1) },
+                    new Datum { Created = new DateTime(2022, 5, 23) },
+                }, "Created", "[,2023]", new Func < Datum, bool > (e => e.Created <= new DateTime(2023, 12, 31)),
+            },
+            // 4. Test exclusive end year
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2022, 12, 31) },
+                    new Datum { Created = new DateTime(2023, 1, 1) },
+                    new Datum { Created = new DateTime(2022, 5, 23) },
+                }, "Created", "[,2023)", new Func < Datum, bool > (e => e.Created <= new DateTime(2022, 12, 31)),
+            },
+            // 5. Test inclusive start and end year
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2022, 12, 31) },
+                    new Datum { Created = new DateTime(2023, 1, 1) },
+                    new Datum { Created = new DateTime(2023, 5, 23) },
+                    new Datum { Created = new DateTime(2024, 12, 31) },
+                    new Datum { Created = new DateTime(2025, 1, 1) },
+                }, "Created", "[2023,2024]", new Func<Datum, bool>(e => e.Created >= new DateTime(2023, 1, 1) && e.Created <= new DateTime(2024, 12, 31)),
+            },
+            // 6. Test inclusive start and end year
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2023, 12, 31) },
+                    new Datum { Created = new DateTime(2024, 1, 1) },
+                    new Datum { Created = new DateTime(2024, 5, 23) },
+                    new Datum { Created = new DateTime(2024, 12, 31) },
+                    new Datum { Created = new DateTime(2025, 1, 1) },
+                }, "Created", "(2023,2025)", new Func<Datum, bool>(e => e.Created >= new DateTime(2024, 1, 1) && e.Created <= new DateTime(2024, 12, 31)),
+            },
+            // 7. Test nullable DateTime property
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Updated = new DateTime(2023, 1, 1) },
+                    new Datum { Updated = new DateTime(2022, 12, 31) },
+                    new Datum { Updated = new DateTime(2024, 5, 23) },
+                }, "Updated", "[2023,]", new Func<Datum, bool>(e => e.Updated >= new DateTime(2023, 1, 1)),
+            },
+            // 8. Test inclusive start year and month
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2024, 2, 29) },
+                    new Datum { Created = new DateTime(2024, 3, 1) },
+                    new Datum { Created = new DateTime(2024, 5, 23) },
+                }, "Created", "[2024-3,]", new Func<Datum, bool>(e => e.Created >= new DateTime(2024, 3, 1)),
+            },
+            // 9. Test exclusive start year and month
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2024, 3, 31) },
+                    new Datum { Created = new DateTime(2024, 4, 1) },
+                    new Datum { Created = new DateTime(2024, 5, 23) },
+                }, "Created", "(2024-3,]", new Func<Datum, bool>(e => e.Created >= new DateTime(2024, 4, 1)),
+            },
+            // 10. Test inclusive end year and month
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2024, 4, 1) },
+                    new Datum { Created = new DateTime(2024, 3, 31) },
+                    new Datum { Created = new DateTime(2024, 2, 23) },
+                }, "Created", "[,2024-3]", new Func<Datum, bool>(e => e.Created <= new DateTime(2024, 3, 31)),
+            },
+            // 11. Test inclusive end year and month with 30 days
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2024, 5, 1) },
+                    new Datum { Created = new DateTime(2024, 4, 30) },
+                    new Datum { Created = new DateTime(2024, 2, 23) },
+                }, "Created", "[,2024-4]", new Func<Datum, bool>(e => e.Created <= new DateTime(2024, 4, 30)),
+            },
+            // 12. Test exclusive end year and month
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2024, 3, 1) },
+                    new Datum { Created = new DateTime(2024, 2, 29) },
+                    new Datum { Created = new DateTime(2024, 1, 23) },
+                }, "Created", "[,2024-3)", new Func<Datum, bool>(e => e.Created <= new DateTime(2024, 2, 29)),
+            },
+            // 13. Test inclusive start and end month
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2024, 1, 31) },
+                    new Datum { Created = new DateTime(2024, 2, 1) },
+                    new Datum { Created = new DateTime(2023, 3, 29) },
+                    new Datum { Created = new DateTime(2024, 4, 30) },
+                    new Datum { Created = new DateTime(2025, 5, 1) },
+                }, "Created", "[2024-2,2024-4]", new Func<Datum, bool>(e => e.Created >= new DateTime(2024, 2, 1) && e.Created <= new DateTime(2024, 4, 30)),
+            },
+            // 14. Test exclusive start and end month
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2024, 2, 29) },
+                    new Datum { Created = new DateTime(2024, 3, 1) },
+                    new Datum { Created = new DateTime(2023, 3, 24) },
+                    new Datum { Created = new DateTime(2024, 3, 31) },
+                    new Datum { Created = new DateTime(2025, 4, 1) },
+                }, "Created", "(2024-2,2024-4)", new Func<Datum, bool>(e => e.Created >= new DateTime(2024, 3, 1) && e.Created <= new DateTime(2024, 3, 31)),
+            },
+            // 15. Test inclusive start day
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2024, 2, 27) },
+                    new Datum { Created = new DateTime(2024, 2, 28) },
+                    new Datum { Created = new DateTime(2024, 3, 29) },
+                }, "Created", "[2024-2-28,]", new Func<Datum, bool>(e => e.Created >= new DateTime(2024, 2, 28)),
+            },
+            // 16. Test exclusive start day
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2024, 2, 28) },
+                    new Datum { Created = new DateTime(2024, 2, 29) },
+                    new Datum { Created = new DateTime(2024, 3, 29) },
+                }, "Created", "(2024-2-28,]", new Func<Datum, bool>(e => e.Created >= new DateTime(2024, 2, 29)),
+            },
+            // 17. Test inclusive end day
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2024, 2, 29) },
+                    new Datum { Created = new DateTime(2024, 2, 28) },
+                    new Datum { Created = new DateTime(2024, 1, 29) },
+                }, "Created", "[,2024-2-28]", new Func<Datum, bool>(e => e.Created <= new DateTime(2024, 2, 28)),
+            },
+            // 18. Test exclusive start day
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2024, 2, 28) },
+                    new Datum { Created = new DateTime(2024, 2, 27) },
+                    new Datum { Created = new DateTime(2024, 1, 29) },
+                }, "Created", "[,2024-2-28)", new Func<Datum, bool>(e => e.Created <= new DateTime(2024, 2, 27)),
+            },
+            // 19. Test inclusive start and end day
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2024, 2, 27) },
+                    new Datum { Created = new DateTime(2024, 2, 28) },
+                    new Datum { Created = new DateTime(2023, 3, 2) },
+                    new Datum { Created = new DateTime(2024, 3, 5) },
+                    new Datum { Created = new DateTime(2025, 3, 6) },
+                }, "Created", "[2024-2-28,2024-3-5]", new Func<Datum, bool>(e => e.Created >= new DateTime(2024, 2, 28) && e.Created <= new DateTime(2024, 3, 5)),
+            },
+            // 20. Test exclusive start and end month
+            new object[] {
+                new List<Datum>() {
+                    new Datum { Created = new DateTime(2024, 2, 28) },
+                    new Datum { Created = new DateTime(2024, 2, 29) },
+                    new Datum { Created = new DateTime(2023, 3, 2) },
+                    new Datum { Created = new DateTime(2024, 3, 4) },
+                    new Datum { Created = new DateTime(2025, 3, 5) },
+                }, "Created", "(2024-2-28,2024-3-5)", new Func<Datum, bool>(e => e.Created >= new DateTime(2024, 2, 29) && e.Created <= new DateTime(2024, 3, 4)),
+            },
+        };
+
+    [Theory]
+    [InlineData("Created", "[,]")]
+    [InlineData("Created", "{2023,]")]
+    [InlineData("Created", "[2023,}")]
+    [InlineData("Created", "[2023:]")]
+    [InlineData("Created", "[0000,]")]
+    [InlineData("Created", "[20023,]")]
+    [InlineData("Created", "[2023/1,]")]
+    [InlineData("Created", "[2023-0,]")]
+    [InlineData("Created", "[2023-13,]")]
+    [InlineData("Created", "[13-2023,]")]
+    [InlineData("Created", "[2023/1/1,]")]
+    [InlineData("Created", "[2023-2-29,]")]
+    [InlineData("Created", "[2024-2-30,]")]
+    [InlineData("Created", "[2023-4-31,]")]
+    [InlineData("Created", "[2023-3-32,]")]
+    public void InvalidFilterDates(string filterProperty, string filterValue)
+    {
+        var property = GetFilterProperty(filterProperty);
+        Assert.Throws<DryException>(() => SampleData.AsQueryable().WhereFilterConditions(new FilterProperty[] { property }, $"{filterProperty}:{filterValue}"));
+    }
+
     private static FilterProperty GetFilterProperty(string propertyName)
     {
         var property = typeof(Datum).GetProperty(propertyName) ?? throw new ArgumentException("Bad argument", nameof(propertyName));
@@ -135,7 +347,8 @@ public class LinqBuilderTests {
         return new FilterProperty(property, filter);
     }
 
-    public class Datum {
+    public class Datum
+    {
 
         [JsonIgnore]
         [Key]
@@ -155,6 +368,12 @@ public class LinqBuilderTests {
         [Filter(FilterType.Equals)]
         [JsonPropertyName("publicName")]
         public string InternalName { get; set; } = string.Empty;
+
+        [Filter]
+        public DateTime Created { get; set; } = DateTime.Now;
+
+        [Filter]
+        public DateTime? Updated { get; set; }
     }
 
     private readonly List<Datum> SampleData = new() {

--- a/ExtraDry/ExtraDry.Server/ExtensionMethods/TypeExtensions.cs
+++ b/ExtraDry/ExtraDry.Server/ExtensionMethods/TypeExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace ExtraDry.Server;
 
 public static class TypeExtensions {
+
     public static object? GetDefaultValue(this Type type)
     {
         if(type.IsValueType && Nullable.GetUnderlyingType(type) == null) {
@@ -8,5 +9,10 @@ public static class TypeExtensions {
         }
 
         return null;
+    }
+
+    public static bool IsTypeOf<T>(this Type type)
+    {
+        return (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>) ? type.GetGenericArguments()[0] : type) == typeof(T);
     }
 }


### PR DESCRIPTION
When filtering using a partial date i.e. `[2024,]` or `[2024-2,]`, the parsing would either fail or create an incorrect date.

These changes parses the dates provided and then adds the missing parts based on if the date is lower or upper, and inclusive or exclusive.