### PR TITLE
Dry table first load.

### DIFF
--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/DryFilterDatePicker.razor
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/DryFilterDatePicker.razor
@@ -8,9 +8,11 @@
         }
     </Button>
     <MiniDialog CssClass="@CssClasses" Title="@Placeholder" @ref="MiniDialog" OnSubmit="@SyncWithPageQuery">
-        <div class="range-buttons" >
-            <Button Caption="Previous" Icon="@PreviousIcon" Enabled="@CanChangeDate" @onclick="@DoPreviousClick" />
-            <Button Caption="Next" Affordance="@NextAffordance" Enabled="@CanChangeDate" @onclick="@DoNextClick" />
+        <div class="controls">
+            <div class="range-buttons" >
+                <Button Caption="Previous" Icon="@PreviousIcon" Enabled="@CanChangeDate" @onclick="@DoPreviousClick" />
+                <Button Caption="Next" Affordance="@NextAffordance" Enabled="@CanChangeDate" @onclick="@DoNextClick" />
+            </div>
             <Button Caption="Clear" @onclick="@DoClearClick" />
         </div>
         @foreach (var group in TimeIntervalGroups)

--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor.cs
@@ -1,4 +1,4 @@
-﻿using ExtraDry.Blazor.Components.Internal;
+using ExtraDry.Blazor.Components.Internal;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
 
 namespace ExtraDry.Blazor;
@@ -284,18 +284,20 @@ public partial class DryTable<TItem> : ComponentBase, IDisposable, IExtraDryComp
                     }
                 }
             }
+            ItemsProviderResult<ListItemInfo<TItem>> result;
             if(InternalItems.Any()) {
                 var count = Math.Min(request.Count, InternalItems.Count);
                 var items = InternalItems.GetRange(request.StartIndex, count);
                 if(!IsHierarchyList) {
                     PerformInitialSort();
                 }
-                return new ItemsProviderResult<ListItemInfo<TItem>>(items, InternalItems.Count);
+                result = new ItemsProviderResult<ListItemInfo<TItem>>(items, InternalItems.Count);
             }
             else {
-                var x = new ItemsProviderResult<ListItemInfo<TItem>>();
-                return x;
+                result = new();
             }
+            firstLoadCompleted = true;
+            return result;
         }
         catch(OperationCanceledException) {
             // KLUDGE: The CancellationTokenSource is initiated in the Virtualize component, but
@@ -306,7 +308,6 @@ public partial class DryTable<TItem> : ComponentBase, IDisposable, IExtraDryComp
         }
         finally {
             serviceLock.Release();
-            firstLoadCompleted = true;
             StateHasChanged(); // update classes affected by InternalItems
         }
         


### PR DESCRIPTION
- Changed when the `DryTable`'s `firstLoadCompleted` flag to only be set after a successful retrieval of data.  This changes the css classes being set to show the components state more accurately.
- Updated the date filters HTML.  This change was missed from #71 