### PR TITLE
Remove unneeded PackageReference Update from projects.

### DIFF
--- a/ExtraDry/ExtraDry.Blazor.Experimental/ExtraDry.Blazor.Experimental.csproj
+++ b/ExtraDry/ExtraDry.Blazor.Experimental/ExtraDry.Blazor.Experimental.csproj
@@ -94,9 +94,4 @@
 		<Folder Include="wwwroot\lib\roosterjs\" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <PackageReference Update="Azure.Identity" Version="1.11.0" />
-	  <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.5" />
-	</ItemGroup>
-
 </Project>

--- a/ExtraDry/ExtraDry.Blazor.Tests/ExtraDry.Blazor.Tests.csproj
+++ b/ExtraDry/ExtraDry.Blazor.Tests/ExtraDry.Blazor.Tests.csproj
@@ -27,9 +27,5 @@
 
 	<Import Project="..\CommonAnalyzers.targets" />
 	<Import Project="..\VulnerabilityFixes.targets" />
-	<ItemGroup>
-	  <PackageReference Update="Azure.Identity" Version="1.11.0" />
-	  <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.5" />
-	</ItemGroup>
 
 </Project>

--- a/ExtraDry/ExtraDry.Blazor/ExtraDry.Blazor.csproj
+++ b/ExtraDry/ExtraDry.Blazor/ExtraDry.Blazor.csproj
@@ -75,9 +75,4 @@
 		</Content>
 	</ItemGroup>
 
-	<ItemGroup>
-	  <PackageReference Update="Azure.Identity" Version="1.11.0" />
-	  <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.5" />
-	</ItemGroup>
-
 </Project>

--- a/ExtraDry/ExtraDry.Core.Tests/ExtraDry.Core.Tests.csproj
+++ b/ExtraDry/ExtraDry.Core.Tests/ExtraDry.Core.Tests.csproj
@@ -41,9 +41,5 @@
 
 	<Import Project="..\CommonAnalyzers.targets" />
 	<Import Project="..\VulnerabilityFixes.targets" />
-	<ItemGroup>
-	  <PackageReference Update="Azure.Identity" Version="1.11.0" />
-	  <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.5" />
-	</ItemGroup>
 
 </Project>

--- a/ExtraDry/ExtraDry.Core/ExtraDry.Core.csproj
+++ b/ExtraDry/ExtraDry.Core/ExtraDry.Core.csproj
@@ -53,11 +53,4 @@
 		</None>
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Update="Azure.Identity" Version="1.11.0" />
-		<PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.5" />
-		<PackageReference Update="Microsoft.IdentityModel.JsonWebTokens" Version="7.3.1" />
-		<PackageReference Update="System.IdentityModel.Tokens.Jwt" Version="7.3.1" />
-	</ItemGroup>
-
 </Project>

--- a/ExtraDry/ExtraDry.Server.Tests/ExtraDry.Server.Tests.csproj
+++ b/ExtraDry/ExtraDry.Server.Tests/ExtraDry.Server.Tests.csproj
@@ -28,9 +28,5 @@
 
 	<Import Project="..\CommonAnalyzers.targets" />
 	<Import Project="..\VulnerabilityFixes.targets" />
-	<ItemGroup>
-	  <PackageReference Update="Azure.Identity" Version="1.11.0" />
-	  <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.5" />
-	</ItemGroup>
 
 </Project>

--- a/ExtraDry/ExtraDry.Server/ExtraDry.Server.csproj
+++ b/ExtraDry/ExtraDry.Server/ExtraDry.Server.csproj
@@ -55,9 +55,5 @@
 
 	<Import Project="..\CommonAnalyzers.targets" />
 	<Import Project="..\VulnerabilityFixes.targets" />
-	<ItemGroup>
-	  <PackageReference Update="Azure.Identity" Version="1.11.0" />
-	  <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.5" />
-	</ItemGroup>
 
 </Project>

--- a/ExtraDry/ExtraDry.Swashbuckle/ExtraDry.Swashbuckle.csproj
+++ b/ExtraDry/ExtraDry.Swashbuckle/ExtraDry.Swashbuckle.csproj
@@ -42,9 +42,4 @@
 		</None>
 	</ItemGroup>
 
-	<ItemGroup>
-	  <PackageReference Update="Azure.Identity" Version="1.11.0" />
-	  <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.5" />
-	</ItemGroup>
-
 </Project>

--- a/ExtraDry/Sample.Data/Sample.Data.csproj
+++ b/ExtraDry/Sample.Data/Sample.Data.csproj
@@ -25,9 +25,4 @@
 		<ProjectReference Include="..\Sample.Shared\Sample.Shared.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <PackageReference Update="Azure.Identity" Version="1.11.0" />
-	  <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.5" />
-	</ItemGroup>
-
 </Project>

--- a/ExtraDry/Sample.Shared/Sample.Shared.csproj
+++ b/ExtraDry/Sample.Shared/Sample.Shared.csproj
@@ -28,9 +28,4 @@
 	  <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <PackageReference Update="Azure.Identity" Version="1.11.0" />
-	  <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.5" />
-	</ItemGroup>
-
 </Project>

--- a/ExtraDry/Sample.Spa.Backend/Sample.Spa.Backend.csproj
+++ b/ExtraDry/Sample.Spa.Backend/Sample.Spa.Backend.csproj
@@ -35,9 +35,4 @@
 	  </None>
 	</ItemGroup>
 
-	<ItemGroup>
-	  <PackageReference Update="Azure.Identity" Version="1.11.0" />
-	  <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.5" />
-	</ItemGroup>
-
 </Project>

--- a/ExtraDry/Sample.Spa.Client/Sample.Spa.Client.csproj
+++ b/ExtraDry/Sample.Spa.Client/Sample.Spa.Client.csproj
@@ -22,9 +22,4 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.1" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <PackageReference Update="Azure.Identity" Version="1.11.0" />
-	  <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.5" />
-	</ItemGroup>
-
 </Project>

--- a/ExtraDry/Sample.Tests/Sample.Tests.csproj
+++ b/ExtraDry/Sample.Tests/Sample.Tests.csproj
@@ -27,9 +27,5 @@
 
 	<Import Project="..\CommonAnalyzers.targets" />
 	<Import Project="..\VulnerabilityFixes.targets" />
-	<ItemGroup>
-	  <PackageReference Update="Azure.Identity" Version="1.11.0" />
-	  <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.5" />
-	</ItemGroup>
-
+	
 </Project>

--- a/ExtraDry/Sample.WebJobs/Sample.WebJobs.csproj
+++ b/ExtraDry/Sample.WebJobs/Sample.WebJobs.csproj
@@ -28,9 +28,5 @@
 
 	<Import Project="..\CommonAnalyzers.targets" />
 	<Import Project="..\VulnerabilityFixes.targets" />
-	<ItemGroup>
-	  <PackageReference Update="Azure.Identity" Version="1.11.0" />
-	  <PackageReference Update="Microsoft.Data.SqlClient" Version="5.1.5" />
-	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Remove unneeded `PackageReference` `Update` from projects.  These are not needed as either the package is not being referenced or the reference is not being updated.