### PR TITLE
Azure.Identity vulnerability upgrade

### DIFF
--- a/ExtraDry/ExtraDry.Core/ExtraDry.Core.csproj
+++ b/ExtraDry/ExtraDry.Core/ExtraDry.Core.csproj
@@ -30,7 +30,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Abstractions" Version="8.0.4" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Abstractions" Version="8.0.6" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
 	</ItemGroup>

--- a/ExtraDry/ExtraDry.Server.Tests/ExtraDry.Server.Tests.csproj
+++ b/ExtraDry/ExtraDry.Server.Tests/ExtraDry.Server.Tests.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
 		<PackageReference Include="xunit" Version="2.6.6" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
 			<PrivateAssets>all</PrivateAssets>

--- a/ExtraDry/ExtraDry.Server/ExtraDry.Server.csproj
+++ b/ExtraDry/ExtraDry.Server/ExtraDry.Server.csproj
@@ -38,8 +38,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.2" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.4">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/ExtraDry/Sample.Data/Sample.Data.csproj
+++ b/ExtraDry/Sample.Data/Sample.Data.csproj
@@ -7,9 +7,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.HierarchyId" Version="8.0.4" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.4">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.HierarchyId" Version="8.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/ExtraDry/Sample.Shared/Sample.Shared.csproj
+++ b/ExtraDry/Sample.Shared/Sample.Shared.csproj
@@ -11,8 +11,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.4" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Abstractions" Version="8.0.4" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="8.0.6" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Abstractions" Version="8.0.6" />
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.1" />
 	</ItemGroup>

--- a/ExtraDry/VulnerabilityFixes.targets
+++ b/ExtraDry/VulnerabilityFixes.targets
@@ -5,10 +5,10 @@
 		<!-- Last checked 2024-04-15 on Azure.Identity vulnerability -->
 		
 		<!-- vulnerability https://github.com/advisories/GHSA-wvxc-855f-jvrv
-			 Requires updated version of Microsoft.EntityFrameworkCore.SqlServer  (currently 8.0.4)
+			 Requires updated version of Microsoft.EntityFrameworkCore.SqlServer  (currently 8.0.6)
 			 which is used by ExtraDry.Server and Sample.Shared
 		-->
-		<PackageReference Include="Azure.Identity" Version="1.11.0" />
+		<PackageReference Include="Azure.Identity" Version="1.11.4" />
 		
 		<!-- vulnerabiltiy https://github.com/advisories/GHSA-5crp-9r3c-p9vr
 			 Requires updated version of Microsoft.EntityFrameworkCore.Cosmos (currently 8.0.4) 


### PR DESCRIPTION
Found a moderate vulnerability in Azure.Identity  1.11.0, checked and upgraded to 1.11.4
https://github.com/advisories/GHSA-m5vv-6r4h-3vj9