### PR TITLE
Strip non-latin characters from slugs

### DIFF
--- a/ExtraDry/ExtraDry.Core.Tests/Core/SlugTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Core/SlugTests.cs
@@ -182,10 +182,10 @@ public class SlugTests
     [InlineData("吴语 [吳語]")]
     public void CodeSlugWithOnlyNonLatinCharacters(string input)
     {
-        var defaultSlugPattern = "\\w{5}\\-\\w{7}";
+        // Without a ToUnique, the slug returned should be what the original processing returns.
         var slug = Slug.ToCodeSlug(input);
 
-        Assert.Matches(defaultSlugPattern, slug);
+        Assert.Equal(string.Empty, slug);
     }
 
     [Theory]
@@ -194,7 +194,7 @@ public class SlugTests
     [InlineData("吴语 [吳語]")]
     public async Task AsyncCodeSlugWithOnlyNonLatinCharacters(string input)
     {
-        var defaultSlugPattern = "\\w{5}\\-\\w{7}";
+        var defaultSlugPattern = @"\w{5}\-\w{7}";
         var slug = await Slug.ToUniqueSlugAsync(input, 20 , slug => GetAsyncList(slug, input));
 
         Assert.Matches(defaultSlugPattern, slug);
@@ -206,7 +206,7 @@ public class SlugTests
     [InlineData("Chinese [吳語]", "Chinese")]
     public void CodeSlugWithMixedNonLatinCharactersIsNotDefaulted(string input, string expected)
     {
-        var defaultSlugPattern = "\\w{5}\\-\\w{7}";
+        var defaultSlugPattern = @"\w{5}\-\w{7}";
         var slug = Slug.ToCodeSlug(input);
 
         Assert.DoesNotMatch(defaultSlugPattern, slug);
@@ -220,7 +220,7 @@ public class SlugTests
     [InlineData("Chinese [吳語]", "Chinese")]
     public async Task CodeSlugWithMixedNonLatinCharactersIsDifferentiated(string input, string expected)
     {
-        var defaultSlugPattern = "\\w{5}\\-\\w{7}";
+        var defaultSlugPattern = @"\w{5}\-\w{7}";
         var slug = await Slug.ToUniqueCodeSlugAsync(input, 20, slug => GetAsyncList(slug, expected));
 
         Assert.DoesNotMatch(defaultSlugPattern, slug);

--- a/ExtraDry/ExtraDry.Core.Tests/Core/SlugTests.cs
+++ b/ExtraDry/ExtraDry.Core.Tests/Core/SlugTests.cs
@@ -1,4 +1,6 @@
-﻿namespace ExtraDry.Core.Tests;
+﻿using System.Text.RegularExpressions;
+
+namespace ExtraDry.Core.Tests;
 
 public class SlugTests
 {
@@ -171,6 +173,58 @@ public class SlugTests
 
         Assert.NotEqual(expected, slug);
         Assert.StartsWith(expected, slug);
+        Assert.Equal(expected.Length + 6, slug.Length);
+    }
+
+    [Theory]
+    [InlineData("٠ ١ ٢ ٣ ٤ ٥ ٦ ٧ ٨ ٩")]
+    [InlineData("🧟💩")]
+    [InlineData("吴语 [吳語]")]
+    public void CodeSlugWithOnlyNonLatinCharacters(string input)
+    {
+        var defaultSlugPattern = "\\w{5}\\-\\w{7}";
+        var slug = Slug.ToCodeSlug(input);
+
+        Assert.Matches(defaultSlugPattern, slug);
+    }
+
+    [Theory]
+    [InlineData("٠ ١ ٢ ٣ ٤ ٥ ٦ ٧ ٨ ٩")]
+    [InlineData("🧟💩")]
+    [InlineData("吴语 [吳語]")]
+    public async Task AsyncCodeSlugWithOnlyNonLatinCharacters(string input)
+    {
+        var defaultSlugPattern = "\\w{5}\\-\\w{7}";
+        var slug = await Slug.ToUniqueSlugAsync(input, 20 , slug => GetAsyncList(slug, input));
+
+        Assert.Matches(defaultSlugPattern, slug);
+    }
+
+    [Theory]
+    [InlineData("٠ ١ ٢ ٣ ٤ ٥ Arabic", "---Arabic")]
+    [InlineData("Tough💩", "Tough")]
+    [InlineData("Chinese [吳語]", "Chinese")]
+    public void CodeSlugWithMixedNonLatinCharactersIsNotDefaulted(string input, string expected)
+    {
+        var defaultSlugPattern = "\\w{5}\\-\\w{7}";
+        var slug = Slug.ToCodeSlug(input);
+
+        Assert.DoesNotMatch(defaultSlugPattern, slug);
+        Assert.Equal(expected, slug);
+    }
+
+
+    [Theory]
+    [InlineData("٠ ١ ٢ ٣ ٤ ٥ Arabic", "---Arabic")]
+    [InlineData("Tough💩", "Tough")]
+    [InlineData("Chinese [吳語]", "Chinese")]
+    public async Task CodeSlugWithMixedNonLatinCharactersIsDifferentiated(string input, string expected)
+    {
+        var defaultSlugPattern = "\\w{5}\\-\\w{7}";
+        var slug = await Slug.ToUniqueCodeSlugAsync(input, 20, slug => GetAsyncList(slug, expected));
+
+        Assert.DoesNotMatch(defaultSlugPattern, slug);
+        Assert.NotEqual(expected, slug);
         Assert.Equal(expected.Length + 6, slug.Length);
     }
     #endregion

--- a/ExtraDry/ExtraDry.Core/Slug.cs
+++ b/ExtraDry/ExtraDry.Core/Slug.cs
@@ -221,11 +221,10 @@ public static class Slug
 
     private static string ToUnique(IEnumerable<string> existing, string stem)
     {
-        var candidate = stem;
-        var hasValidStemCondition = stem.Any(c => c != '-');  // If the name is empty or is composed of only invalid characters, generate a random slug replacement rather than appending.
-        if(!hasValidStemCondition) {
-            candidate = GenerateGenericSlug();
-        }
+        // If the name has any non-hyphen characters, we'll use that as the stem. Else we'll generate a generic slug
+        var hasValidStemCondition = stem.Any(IsAsciiLetterOrDigit);
+        var candidate = hasValidStemCondition ? stem : GenerateGenericSlug();
+
         while(existing.Contains(candidate)) {
             candidate = hasValidStemCondition ? $"{stem}-{RandomWebString(5)}" : GenerateGenericSlug();
         }
@@ -242,11 +241,10 @@ public static class Slug
 
     private static async Task<string> ToUniqueAsync(Func<string, Task<bool>> existsAsync, string stem)
     {
-        var candidate = stem;
-        var hasValidStemCondition = stem.Any(c => c != '-');  // If the name is empty or is composed of only invalid characters, generate a random slug replacement rather than appending.
-        if(!hasValidStemCondition) {
-            candidate = GenerateGenericSlug();
-        }
+        // If the name has any non-hyphen characters, we'll use that as the stem. Else we'll generate a generic slug
+        var hasValidStemCondition = stem.Any(IsAsciiLetterOrDigit);
+        var candidate = hasValidStemCondition ? stem : GenerateGenericSlug();
+
         while(await existsAsync(candidate)) {
             candidate = hasValidStemCondition ? $"{stem}-{RandomWebString(5)}" : GenerateGenericSlug();
         }

--- a/ExtraDry/ExtraDry.Core/Slug.cs
+++ b/ExtraDry/ExtraDry.Core/Slug.cs
@@ -181,6 +181,17 @@ public static class Slug
         return RandomCharacters(count, characters);
     }
 
+    /// <summary>
+    /// Used to determine if a character can be used in a slug.
+    /// </summary>
+    /// <remarks>
+    /// Used instead of char.IsLetterOrDigit becuase that doesn't discriminate on charater set, which can allow invalid characters for urls
+    /// </remarks>
+    private static bool IsLatinLetterOrDigit(char c)
+    {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+    }
+
     private static string ToSlugInternal(string name, bool lowercase = true, string okCharacters = @"_")
     {
         if(string.IsNullOrWhiteSpace(name)) {
@@ -191,7 +202,7 @@ public static class Slug
         var hiddenCharacters = ".'"; // exclude to contract abbreviations and possessives.
         name = RemoveCommonNameSuffixes(name);
         foreach(var c in name) {
-            if(char.IsLetterOrDigit(c)) {
+            if(IsLatinLetterOrDigit(c) ) {
                 sb.Append(lowercase ? char.ToLowerInvariant(c) : c);
             }
             else if(okCharacters.Contains(c)) {
@@ -202,6 +213,9 @@ public static class Slug
             }
         }
         name = sb.ToString();
+        if(name.All(c => c == '-')) {  // If the name is composed of only invalid characters, generate a random slug replacement.
+            name = $"{RandomWebString(5)}-{RandomWebString(7)}";
+        }
         name = name.Replace("--", "-");
         name = name.Replace("--", "-");
         name = name.TrimEnd('-');


### PR DESCRIPTION
Change the slug logic to only consider Latin letters and characters as acceptable characters.
Add unit tests
Add condition to slug logic where if all characters aren't valid, a placeholder slug is generated.