### PR TITLE
Provide override for form property size.

### DIFF
--- a/ExtraDry/ExtraDry.Blazor.Tests/Models/PropertyDescriptionTests.cs
+++ b/ExtraDry/ExtraDry.Blazor.Tests/Models/PropertyDescriptionTests.cs
@@ -1,0 +1,124 @@
+﻿using ExtraDry.Core;
+using System.ComponentModel.DataAnnotations;
+
+namespace ExtraDry.Blazor.Tests.Models;
+
+public class PropertyDescriptionTests
+{
+    [Fact]
+    public void CreateObject()
+    {
+        var propertyDescription = new PropertyDescription(typeof(SizeAndLengthTestModel).GetProperty(nameof(SizeAndLengthTestModel.Unset))!);
+
+        Assert.NotNull(propertyDescription);
+    }
+
+    #region Size and Length tests
+
+    [Theory]
+    [InlineData(nameof(SizeAndLengthTestModel.Unset), PropertySize.Jumbo)]
+    [InlineData(nameof(SizeAndLengthTestModel.SmallStringLength), PropertySize.Small)]
+    [InlineData(nameof(SizeAndLengthTestModel.MediumStringLength), PropertySize.Medium)]
+    [InlineData(nameof(SizeAndLengthTestModel.LargeStringLength), PropertySize.Large)]
+    [InlineData(nameof(SizeAndLengthTestModel.JumboStringLength), PropertySize.Jumbo)]
+    [InlineData(nameof(SizeAndLengthTestModel.SmallMaxLength), PropertySize.Small)]
+    [InlineData(nameof(SizeAndLengthTestModel.MediumMaxLength), PropertySize.Medium)]
+    [InlineData(nameof(SizeAndLengthTestModel.LargeMaxLength), PropertySize.Large)]
+    [InlineData(nameof(SizeAndLengthTestModel.JumboMaxLength), PropertySize.Jumbo)]
+    public void SizeAndLength(string propertyName, PropertySize expectedSize)
+    {
+        var propertyDescription = new PropertyDescription(typeof(SizeAndLengthTestModel).GetProperty(propertyName)!);
+
+        Assert.Equal(expectedSize, propertyDescription.Size);
+        Assert.Equal(expectedSize, propertyDescription.Length);
+    }
+
+    [Theory]
+    [InlineData(nameof(SizeAndLengthTestModel.UnsetSetSmall), PropertySize.Jumbo, PropertySize.Small)]
+    [InlineData(nameof(SizeAndLengthTestModel.SmallStringLengthSetMedium), PropertySize.Small, PropertySize.Medium)]
+    [InlineData(nameof(SizeAndLengthTestModel.MediumStringLengthSetLarge), PropertySize.Medium, PropertySize.Large)]
+    [InlineData(nameof(SizeAndLengthTestModel.LargeStringLengthSetJumbo), PropertySize.Large, PropertySize.Jumbo)]
+    [InlineData(nameof(SizeAndLengthTestModel.JumboStringLengthSetSmall), PropertySize.Jumbo, PropertySize.Small)]
+    [InlineData(nameof(SizeAndLengthTestModel.SmallMaxLengthSetMedium), PropertySize.Small, PropertySize.Medium)]
+    [InlineData(nameof(SizeAndLengthTestModel.MediumMaxLengthSetLarge), PropertySize.Medium, PropertySize.Large)]
+    [InlineData(nameof(SizeAndLengthTestModel.LargeMaxLengthSetJumbo), PropertySize.Large, PropertySize.Jumbo)]
+    [InlineData(nameof(SizeAndLengthTestModel.JumboMaxLengthSetSmall), PropertySize.Jumbo, PropertySize.Small)]
+    public void SizeAndLengthWithOverride(string propertyName, PropertySize expectedSize, PropertySize expectedLength)
+    {
+        var propertyDescription = new PropertyDescription(typeof(SizeAndLengthTestModel).GetProperty(propertyName)!);
+
+        Assert.Equal(expectedSize, propertyDescription.Size);
+        Assert.Equal(expectedLength, propertyDescription.Length);
+    }
+
+    private class SizeAndLengthTestModel
+    {
+        public string Unset { get; set; } = string.Empty;
+
+        [StringLength(25)]
+        public string SmallStringLength { get; set; } = string.Empty;
+
+        [StringLength(50)]
+        public string MediumStringLength { get; set; } = string.Empty;
+
+        [StringLength(100)]
+        public string LargeStringLength { get; set; } = string.Empty;
+
+        [StringLength(101)]
+        public string JumboStringLength { get; set; } = string.Empty;
+
+#pragma warning disable DRY1310 // Prefer the use of StringLength instead of MaxLength.
+        [MaxLength(25)]
+        public string SmallMaxLength { get; set; } = string.Empty;
+
+        [MaxLength(50)]
+        public string MediumMaxLength { get; set; } = string.Empty;
+
+        [MaxLength(100)]
+        public string LargeMaxLength { get; set; } = string.Empty;
+
+        [MaxLength(101)]
+        public string JumboMaxLength { get; set; } = string.Empty;
+#pragma warning restore DRY1310 // Prefer the use of StringLength instead of MaxLength.
+
+        [InputFormat(Size = PropertySize.Small)]
+        public string UnsetSetSmall { get; set; } = string.Empty;
+
+        [StringLength(25)]
+        [InputFormat(Size = PropertySize.Medium)]
+        public string SmallStringLengthSetMedium { get; set; } = string.Empty;
+
+        [StringLength(50)]
+        [InputFormat(Size = PropertySize.Large)]
+        public string MediumStringLengthSetLarge { get; set; } = string.Empty;
+
+        [StringLength(100)]
+        [InputFormat(Size = PropertySize.Jumbo)]
+        public string LargeStringLengthSetJumbo { get; set; } = string.Empty;
+
+        [StringLength(101)]
+        [InputFormat(Size = PropertySize.Small)]
+        public string JumboStringLengthSetSmall { get; set; } = string.Empty;
+
+#pragma warning disable DRY1310 // Prefer the use of StringLength instead of MaxLength.
+        [MaxLength(25)]
+        [InputFormat(Size = PropertySize.Medium)]
+        public string SmallMaxLengthSetMedium { get; set; } = string.Empty;
+
+        [MaxLength(50)]
+        [InputFormat(Size = PropertySize.Large)]
+        public string MediumMaxLengthSetLarge { get; set; } = string.Empty;
+
+        [MaxLength(100)]
+        [InputFormat(Size = PropertySize.Jumbo)]
+        public string LargeMaxLengthSetJumbo { get; set; } = string.Empty;
+
+        [MaxLength(101)]
+        [InputFormat(Size = PropertySize.Small)]
+        public string JumboMaxLengthSetSmall { get; set; } = string.Empty;
+#pragma warning restore DRY1310 // Prefer the use of StringLength instead of MaxLength.
+
+    }
+
+    #endregion
+}

--- a/ExtraDry/ExtraDry.Blazor/Internal/FormDescription.cs
+++ b/ExtraDry/ExtraDry.Blazor/Internal/FormDescription.cs
@@ -1,4 +1,3 @@
-﻿using System.Collections;
 using System.Collections.ObjectModel;
 
 namespace ExtraDry.Blazor.Internal;
@@ -106,7 +105,7 @@ internal class FormDescription {
                 ExtendedProperties.Add(new ExtendedProperty(property, model) { 
                     FieldsetTitle = fieldsetName,
                     GroupType = formGroup,
-                    Length = property.Size,
+                    Length = property.Length,
                     ParentTarget = parentModel,
                 });
             }

--- a/ExtraDry/ExtraDry.Blazor/Models/PropertyDescription.cs
+++ b/ExtraDry/ExtraDry.Blazor/Models/PropertyDescription.cs
@@ -93,7 +93,18 @@ public class PropertyDescription
 
     public PropertyInfo Property { get; set; }
 
-    public PropertySize Size { get; set; }
+    /// <summary>
+    /// The calculated size of the property.
+    /// </summary>
+    public PropertySize Size { get; private set; }
+
+    /// <summary>
+    /// The amount of the line that the property should consume.
+    /// </summary>
+    /// <remarks>
+    /// Takes into account any consumer overrides.
+    /// </remarks>
+    public PropertySize Length => (InputFormat is not null && InputFormat.Size != PropertySize.Calculated) ? InputFormat.Size : Size;
 
     public string DisplayValue(object? item)
     {

--- a/ExtraDry/ExtraDry.Core/Core/InputFormatAttribute.cs
+++ b/ExtraDry/ExtraDry.Core/Core/InputFormatAttribute.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace ExtraDry.Core;
 
 /// <summary>
@@ -13,12 +13,14 @@ public class InputFormatAttribute : Attribute
     public Type? DataTypeOverride { get; set; }
 
     /// <summary>
-    /// The icon to be used in the display of this propertys input, typically on the left of the input
+    /// The icon to be used in the display of this property's input, typically on the left of the input
     /// </summary>
     public string? Icon { get; set; }
 
     /// <summary>
-    /// The affordance icon to be used in the display of this propertys input, typically on the right of the input.
+    /// The affordance icon to be used in the display of this property's input, typically on the right of the input.
     /// </summary>
     public string? Affordance { get; set; }
+
+    public PropertySize Size { get; set; } = PropertySize.Calculated;
 }

--- a/ExtraDry/ExtraDry.Core/Core/PropertySize.cs
+++ b/ExtraDry/ExtraDry.Core/Core/PropertySize.cs
@@ -1,10 +1,15 @@
-﻿namespace ExtraDry.Blazor;
+﻿namespace ExtraDry.Core;
 
 /// <summary>
 /// A semantic description of the size of a property, used to determine how to layout forms.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PropertySize {
+
+    /// <summary>
+    /// Size is calculated based on the property details.
+    /// </summary>
+    Calculated = 0,
 
     /// <summary>
     /// A small property, such as an int field, small enough to fit four fields on a single line.

--- a/ExtraDry/Sample.Shared/Entitites/Company.cs
+++ b/ExtraDry/Sample.Shared/Entitites/Company.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
-using System.ComponentModel;
+using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Sample.Shared;
@@ -77,10 +76,11 @@ public class Company : IResourceIdentifiers {
 
     [EmailAddress, StringLength(100)]
     [Rules(RuleAction.IgnoreDefaults)]
+    [InputFormat(Size = PropertySize.Jumbo)]
     public string ContactEmail { get; set; } = "";
 
     [Precision(18, 2)]
-    [InputFormat(Icon = "currency")]
+    [InputFormat(Icon = "currency", Size = PropertySize.Calculated)]
     public decimal AnnualRevenue { get; set; }
 
     [Display(Prompt = "0.00", Description = "Clamped to range [0, 120]")]

--- a/ExtraDry/Sample.Spa.Backend/SampleData/SampleDataService.cs
+++ b/ExtraDry/Sample.Spa.Backend/SampleData/SampleDataService.cs
@@ -74,6 +74,7 @@ public partial class SampleDataService {
                     Uuid = PseudoRandomGuid(),
                     Slug = Slug.RandomWebString(6),
                     Title = name,
+                    Description = name,
                     PrimarySector = PickRandom(services),
                     Status = PickRandom(companyStatuses),
                     AnnualRevenue = random.Next(1_000_000, 3_000_000),


### PR DESCRIPTION
Added a new `Size` property to the `InputFormatAttribute` to allow consumers to override the calculated property size.  The overriding size is used when determining the number of properties in a form row.   The calculated size is still used for the CSS class.

The `Company.cs` was only updated with a couple of test cases, I think the changes highlighted in the diff are due to the line endings being updated by Visual Studio.

There was an existing issue with loading the sample company data, I've added the fix for this into this pull request in the `SampleDataService.cs` file